### PR TITLE
fix: progress bar scaling

### DIFF
--- a/polymer/src/elements/etools-prp-progress-bar.html
+++ b/polymer/src/elements/etools-prp-progress-bar.html
@@ -6,7 +6,7 @@
 
 <dom-module id="etools-prp-progress-bar">
   <template>
-  <style include="progress-bar"></style>
+    <style include="progress-bar"></style>
     <!-- TODO: percentage is going to be returned from the backend -->
     <!-- TODO: Change color to green if it's a cluster item (not in this sprint). -->
     <paper-progress value="[[percentage]]"

--- a/polymer/src/styles/progress-bar.html
+++ b/polymer/src/styles/progress-bar.html
@@ -3,10 +3,21 @@
 <dom-module id="progress-bar">
   <template>
     <style>
+        :host {
+          width: 100%;
+          min-width: 50px;
+          max-width: 300px;
+        }
         paper-progress {
           --paper-progress-height: 15px;
-          margin-right: 15px;
+          width: 87%;
+          margin-right: 3%;
           float: left;
+        }
+        span {
+          display: block;
+          float: left;
+          width: 10%;
         }
         #primaryProgress, #secondaryProgress {
           height: 15px;


### PR DESCRIPTION
### This PR addresses (ticket title)
Progress bar scaling #92
https://github.com/unicef/etools-partner-reporting-portal/issues/92

##### Feature list
+ bar will scale to the size of the column (but with min and max widths)
+ text will never drop below the bar

##### Progress checker
- [ ] Django

- [X] Polymer

- [ ] Django test cases

- [ ] Polymer test cases
