### PR TITLE
Fix: details don't collapse on pagination #123

### DIFF
--- a/polymer/src/behaviors/pagination.html
+++ b/polymer/src/behaviors/pagination.html
@@ -30,6 +30,9 @@
       },
 
       _computePageNumber: function (queryParams) {
+        document.querySelectorAll('* /deep/ #details').forEach(function (details) {
+          if (details.opened) details.toggle();
+        });
         return this._toNumber(queryParams.page || 1);
       },
 

--- a/polymer/src/behaviors/pagination.html
+++ b/polymer/src/behaviors/pagination.html
@@ -30,9 +30,6 @@
       },
 
       _computePageNumber: function (queryParams) {
-        document.querySelectorAll('* /deep/ #details').forEach(function (details) {
-          if (details.opened) details.toggle();
-        });
         return this._toNumber(queryParams.page || 1);
       },
 

--- a/polymer/src/elements/ip-reporting/list-view-indicators.html
+++ b/polymer/src/elements/ip-reporting/list-view-indicators.html
@@ -98,8 +98,32 @@
           type: Number,
           statePath: 'indicators.count'
         },
+
+        openedDetails: {
+          type: Array,
+          value: []
+        }
       },
 
+      listeners: {
+        'page-number-changed':'_pageNumberModified',
+        'details-opened-changed':'_detailsChange'
+      },
+
+      _pageNumberModified: function () {
+        var tempList = this.openedDetails.slice();
+        tempList.forEach(function (details) {
+          details.detailsOpened = false
+        });
+      },
+
+      _detailsChange: function () {
+        var element = Polymer.dom(event).rootTarget
+        var isOpen = element.detailsOpened;
+        if (isOpen) return this.push('openedDetails', element)
+        var index = this.openedDetails.indexOf(element);
+        if (index !== -1) return this.splice('openedDetails', index, 1);
+      }
     });
   </script>
 </dom-module>

--- a/polymer/src/elements/ip-reporting/list-view-indicators.html
+++ b/polymer/src/elements/ip-reporting/list-view-indicators.html
@@ -106,23 +106,31 @@
       },
 
       listeners: {
-        'page-number-changed':'_pageNumberModified',
-        'details-opened-changed':'_detailsChange'
+        'page-number-changed': '_pageNumberModified',
+        'details-opened-changed': '_detailsChange'
       },
 
       _pageNumberModified: function () {
         var tempList = this.openedDetails.slice();
         tempList.forEach(function (details) {
-          details.detailsOpened = false
+          details.detailsOpened = false;
         });
       },
 
       _detailsChange: function () {
-        var element = Polymer.dom(event).rootTarget
+        var element = Polymer.dom(event).rootTarget;
         var isOpen = element.detailsOpened;
-        if (isOpen) return this.push('openedDetails', element)
+        if (isOpen) {
+          return this.push('openedDetails', element);
+        }
         var index = this.openedDetails.indexOf(element);
-        if (index !== -1) return this.splice('openedDetails', index, 1);
+        if (index !== -1) {
+          return this.splice('openedDetails', index, 1);
+        }
+      },
+
+      detached: function () {
+        this.openedDetails.length = 0;
       }
     });
   </script>


### PR DESCRIPTION
### This PR addresses Pagination vs. row details #123 

##### Feature list
* _Describe the list of features from Django_

* _Describe the list of features from Polymer_
      - added function to collapse all details on page number change event
      - had to hijack event emitted by pagination element, as new event clashed with this one and I see this as a problem since we will add extra collapsing to page change on every list.

But simply dropping this handler into list-view-indicators.html seems to break the first handler (no request and data update happens)

```
      _pageNumberChanged: function () {
        document.querySelectorAll('* /deep/ #details').forEach(function (details) {
          if (details.opened) details.toggle();
        });
      }
```

##### Progress checker
- [ ] Django

- [ ] Polymer

- [ ] Django test cases

- [ ] Polymer test cases
