### PR TITLE
Fix - is_complete Flag for IndicatorLocationData [#156]

### DIFF
--- a/django_api/django_api/apps/indicator/serializers.py
+++ b/django_api/django_api/apps/indicator/serializers.py
@@ -166,6 +166,10 @@ class SimpleIndicatorLocationDataListSerializer(serializers.ModelSerializer):
     location_progress = serializers.SerializerMethodField()
     previous_location_progress = serializers.SerializerMethodField()
     display_type = serializers.SerializerMethodField()
+    is_complete = serializers.SerializerMethodField()
+
+    def get_is_complete(self, obj):
+        return True if obj.disaggregation else False
 
     def get_display_type(self, obj):
         return obj.indicator_report.display_type
@@ -218,6 +222,7 @@ class SimpleIndicatorLocationDataListSerializer(serializers.ModelSerializer):
             'disaggregation_reported_on',
             'location_progress',
             'previous_location_progress',
+            'is_complete',
         )
 
 


### PR DESCRIPTION
This PR addresses a new API field called `is_complete` to indicate that location data is complete if any disaggregation data is filled.

### This PR addresses location data complete flag

##### Feature list
* _Describe the list of features from Django_

* is_complete SerializerMethodField on SimpleIndicatorLocationDataListSerializer

##### Progress checker
- [x] Django
