### PR TITLE
Adding tabs to the ip-reporting indicator details page (to be reused …

### DIFF
--- a/polymer/src/elements/cluster-reporting/project-list-table.html
+++ b/polymer/src/elements/cluster-reporting/project-list-table.html
@@ -110,7 +110,7 @@
                 [[_commaSeparatedListValues(project.locations)]]
               </div>
             </div>
-            <div slot="row-data-details">
+            <div slot="row-data-details" class="row-details-dropdown-wrapper">
               <div slot="row-data">
                 <div class="table-cell table-cell--text">
                   <span class="label">Start Date</span>

--- a/polymer/src/elements/cluster-reporting/project-list-table.html
+++ b/polymer/src/elements/cluster-reporting/project-list-table.html
@@ -110,7 +110,7 @@
                 [[_commaSeparatedListValues(project.locations)]]
               </div>
             </div>
-            <div slot="row-data-details" class="row-details-dropdown-wrapper">
+            <div slot="row-data-details" class="row-details-expanded-wrapper">
               <div slot="row-data">
                 <div class="table-cell table-cell--text">
                   <span class="label">Start Date</span>

--- a/polymer/src/elements/etools-prp-data-table-row.html
+++ b/polymer/src/elements/etools-prp-data-table-row.html
@@ -58,13 +58,6 @@ This allows Ajax calls to be made only upon click. -->
       iron-icon:hover {
         color: var(--list-icon-hover-color, rgba(0, 0, 0, 0.87));
       }
-
-      #collapse-wrapper {
-        padding: 15px 24px 15px 72px;
-        background-color: var(--paper-grey-100);
-        border-top: 1px solid var(--list-divider-color, #9D9D9D);
-      }
-
     </style>
 
     <paper-material id="wrapper" elevation="0">

--- a/polymer/src/elements/ip-reporting/ip-reporting-indicator-details.html
+++ b/polymer/src/elements/ip-reporting/ip-reporting-indicator-details.html
@@ -1,6 +1,9 @@
 <link rel="import" href="../../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../../bower_components/iron-icons/maps-icons.html">
 <link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
+<link rel="import" href="../../../bower_components/paper-tabs/paper-tab.html">
+<link rel="import" href="../../../bower_components/paper-tabs/paper-tabs.html">
+<link rel="import" href="../../../bower_components/iron-pages/iron-pages.html">
 
 <link rel="import" href="../../behaviors/utils.html">
 <link rel="import" href="../etools-prp-ajax.html">
@@ -18,7 +21,13 @@
         width: 100%;
         /*Required so the loading message isn't cut off:*/
         min-height: 250px;
+
+        --paper-tabs: {
+          padding-left: 13px;
+          border-bottom: 1px solid var(--paper-grey-300);
+        };
       }
+
       iron-icon {
         color: var(--accent-color);
       }
@@ -42,60 +51,74 @@
       <div>
     </template>
 
-    <template is="dom-repeat"
-              items="[[locations]]"
-              as="location">
+    <paper-tabs
+        selected="{{selected}}"
+        fallback-selection="location-[[locations.0.current.id]]"
+        attr-for-selected="name"
+        scrollable
+        hide-scroll-buttons>
+      <template
+          is="dom-repeat"
+          items="[[locations]]"
+          as="location">
+        <paper-tab name="location-[[location.current.id]]">
+          [[location.name]]
+        </paper-tab>
+      </template>
+    </paper-tabs>
 
-      <h3>
-        <iron-icon icon="maps:place"></iron-icon>
-        [[location.name]]
-      </h3>
+    <iron-pages
+        attr-for-selected="name"
+        selected="{{selected}}">
 
-      <div class="container">
-        <template is="dom-if" if="[[location.current]]">
-          <div class="item">
-            <h4>
-              <span>
-                <strong>Progress in current reporting period: </strong>
-                [[location.reportInfo.time_period_start]] -
-                [[location.reportInfo.time_period_end]]
-              </span>
-              <span class="total">
-                <strong>Total: </strong>[[location.reportInfo.total.v]]
-              </span>
-            </h4>
-            <p>Level reported: [[location.current.level_reported]]</p>
-            <!-- TODO: check - wrong use of total? -->
-            <disaggregation-table
-              data=[[location.current]]
-              mapping=[[location.reportInfo.disagg_lookup_map]]>
-            </disaggregation-table>
+      <template
+          is="dom-repeat"
+          items="[[locations]]"
+          as="location">
+        <div name="location-[[location.current.id]]">
+          <div class="container">
+            <template is="dom-if" if="[[location.current]]">
+              <div class="item">
+                <h4>
+                  <span>
+                    <strong>Progress in current reporting period: </strong>
+                    [[location.reportInfo.time_period_start]] -
+                    [[location.reportInfo.time_period_end]]
+                  </span>
+                  <span class="total">
+                    <strong>Total: </strong>[[location.reportInfo.total.v]]
+                  </span>
+                </h4>
+                <!-- TODO: check - wrong use of total? -->
+                <disaggregation-table
+                  data=[[location.current]]
+                  mapping=[[location.reportInfo.disagg_lookup_map]]>
+                </disaggregation-table>
+              </div>
+            </template>
+
+            <template is="dom-if" if="[[location.previous]]">
+              <div class="item">
+                <h4>
+                  <span>
+                    <strong>Progress in previous reporting period: </strong>
+                    [[location.reportInfo.time_period_start]] -
+                    [[location.reportInfo.time_period_end]]
+                  </span>
+                  <span class="total">
+                    <strong>Total: </strong>[[location.reportInfo.total.v]]
+                  </span>
+                </h4>
+                <disaggregation-table
+                  data=[[location.previous]]
+                  mapping=[[location.reportInfo.disagg_lookup_map]]>
+                </disaggregation-table>
+              </div>
+            </template>
           </div>
-        </template>
-
-        <template is="dom-if" if="[[location.previous]]">
-          <div class="item">
-            <h4>
-              <span>
-                <strong>Progress in previous reporting period: </strong>
-                [[location.reportInfo.time_period_start]] -
-                [[location.reportInfo.time_period_end]]
-              </span>
-              <span class="total">
-                <strong>Total: </strong>[[location.reportInfo.total.v]]
-              </span>
-            </h4>
-            <p>Level reported: [[location.previous.level_reported]]</p>
-            <disaggregation-table
-              data=[[location.previous]]
-              mapping=[[location.reportInfo.disagg_lookup_map]]>
-            </disaggregation-table>
-          </div>
-        </template>
-      </div>
-
-    </template>
-
+        </div>
+      </template>
+    </iron-pages>
   </template>
 
   <script>
@@ -111,6 +134,11 @@
         indicatorDetailUrl: {
           type: String,
           computed: '_computeIndicatorReportsUrl(indicatorId)',
+        },
+
+        selected: {
+          type: Number,
+          value: 0,
         },
 
         isOpen: {
@@ -157,13 +185,14 @@
         if (!data) {
           return [];
         }
+
         data.forEach(function(report, index) {
           var timeframe = 'current';
           if (index === 1) {
             timeframe = 'previous';
           }
 
-          report.indicator_location_data.forEach(function(locationReport) {
+          report.indicator_location_data.forEach(function(locationReport, index) {
             if (locations[locationReport.location.id]) {
               var toUpdate = locations[locationReport.location.id];
               toUpdate[timeframe] = locationReport;
@@ -184,6 +213,7 @@
           locationList.push(locations[i]);
         });
 
+        console.log("locationList", locationList)
         return locationList;
       },
 

--- a/polymer/src/elements/ip-reporting/ip-reporting-indicator-details.html
+++ b/polymer/src/elements/ip-reporting/ip-reporting-indicator-details.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../../../bower_components/polymer/polymer.html">
-<link rel="import" href="../../../bower_components/iron-icons/maps-icons.html">
 <link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="../../../bower_components/paper-tabs/paper-tab.html">
 <link rel="import" href="../../../bower_components/paper-tabs/paper-tabs.html">
@@ -28,9 +27,6 @@
         };
       }
 
-      iron-icon {
-        color: var(--accent-color);
-      }
       h3 {
         width: 100%;
         float: left;
@@ -192,7 +188,7 @@
             timeframe = 'previous';
           }
 
-          report.indicator_location_data.forEach(function(locationReport, index) {
+          report.indicator_location_data.forEach(function(locationReport) {
             if (locations[locationReport.location.id]) {
               var toUpdate = locations[locationReport.location.id];
               toUpdate[timeframe] = locationReport;
@@ -213,7 +209,6 @@
           locationList.push(locations[i]);
         });
 
-        console.log("locationList", locationList)
         return locationList;
       },
 

--- a/polymer/src/elements/ip-reporting/list-view-single-indicator.html
+++ b/polymer/src/elements/ip-reporting/list-view-single-indicator.html
@@ -10,6 +10,9 @@
   <template>
 
     <style include="iron-flex iron-flex-factors data-table-styles table-styles">
+      :host {
+        display: block;
+      }
     </style>
 
     <etools-prp-data-table-row details-opened="{{detailsOpened}}">

--- a/polymer/src/pages/app/cluster-reporting/select-plan.html
+++ b/polymer/src/pages/app/cluster-reporting/select-plan.html
@@ -161,7 +161,7 @@
                 </div>
               </div>
 
-              <div slot="row-data-details">
+              <div slot="row-data-details" class="row-details-dropdown-wrapper">
                 <template is="dom-if" if="[[!plan.documents.length]]">
                   There are no documents for this response plan.
                 </template>

--- a/polymer/src/pages/app/cluster-reporting/select-plan.html
+++ b/polymer/src/pages/app/cluster-reporting/select-plan.html
@@ -161,7 +161,7 @@
                 </div>
               </div>
 
-              <div slot="row-data-details" class="row-details-dropdown-wrapper">
+              <div slot="row-data-details" class="row-details-expanded-wrapper">
                 <template is="dom-if" if="[[!plan.documents.length]]">
                   There are no documents for this response plan.
                 </template>

--- a/polymer/src/styles/table-styles.html
+++ b/polymer/src/styles/table-styles.html
@@ -55,7 +55,7 @@
         --list-icon-color: var(--paper-grey-500);
       }
 
-      .row-details-dropdown-wrapper {
+      .row-details-expanded-wrapper {
         padding: 15px 24px 15px 72px;
         background-color: var(--paper-grey-100);
         border-top: 1px solid var(--list-divider-color, #9D9D9D);

--- a/polymer/src/styles/table-styles.html
+++ b/polymer/src/styles/table-styles.html
@@ -54,6 +54,12 @@
       etools-data-table-footer {
         --list-icon-color: var(--paper-grey-500);
       }
+
+      .row-details-dropdown-wrapper {
+        padding: 15px 24px 15px 72px;
+        background-color: var(--paper-grey-100);
+        border-top: 1px solid var(--list-divider-color, #9D9D9D);
+      }
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
…for cluster reporting)

This branch is a (small) part of #220 (adding indicators to cluster reporting).  The ticket requires the addition of tabs to the indicators list currently used in IP Reporting (being re-used for clusters).

This PR does not address #220, which is mostly handled in the branch feature-add-indicators-to-detail-tabs-#220.

In this PR:
+ Added tabs for indicator locations
+ Removed collapse-wrapper styling from etools-prp-data-table-row because with the addition of tabs, the details dropdown needs different styling for indicators

### This PR addresses (tic
- [x] Polymer

- [ ] Polymer test cases
