### PR TITLE
Removing 'All' option from the cluster dropdown used in creation modals

### DIFF
--- a/polymer/src/elements/form-fields/cluster-dropdown-input.html
+++ b/polymer/src/elements/form-fields/cluster-dropdown-input.html
@@ -80,10 +80,7 @@
 
         this.$.clusterNames.thunk()()
             .then(function (res) {
-              self.set('data', [{
-                id: '',
-                title: 'All',
-              }].concat(res.data));
+              self.set('data', res.data);
             })
             .catch(function (err) { // jshint ignore:line
               // TODO: error handling


### PR DESCRIPTION
Cluster dropdown when creating a cluster objective or activity "All" option is not correct / not needed.

This resolves #231.

PR probably not necessary, but doing it for consistency.

##### Progress checker
- [x] Polymer

- [ ] Polymer test cases
