### PR TITLE
Finding parent node of radio button to fix cross-browser issue

### DIFF
--- a/polymer/src/pages/app/cluster-reporting/select-plan.html
+++ b/polymer/src/pages/app/cluster-reporting/select-plan.html
@@ -144,7 +144,7 @@
                   <paper-radio-button
                     checked="[[_determineIfChecked(selected, plan.id)]]"
                     name="[[plan.id]]"
-                    on-tap="_selectRadioButton">
+                    on-tap="_handleRadioButtonChange">
                   </paper-radio-button>
                 </div>
                 <div class="table-cell" flex-2>
@@ -234,11 +234,22 @@
         return false;
       },
 
-      // Note: paper-radio-group requires the radio buttons to be directly nested,
-      // so it will not work for this component.
-      _selectRadioButton: function(e) {
-        if (e.target.checked) {
-          this.selected = e.target.name;
+      /*
+      Note:
+      paper-radio-group requires the radio buttons to be directly nested.
+      It will not work for this component.
+      on-tap and change events target different elements in Chrome than in Safari and FF.
+      */
+
+      //Gets correct target element when using Chrome.
+      _handleRadioButtonChange: function(e) {
+        var target = e.target;
+        if (e.target.id === 'onRadio' || e.target.id === 'offRadio') {
+          target = e.target.parentNode.parentNode;
+        }
+
+        if (target.checked) {
+          this.selected = target.name;
         } else {
           this.selected = null;
         }


### PR DESCRIPTION
This PR addresses: Cross-browser problem with radio buttons in Select Plan page

This resolves #253.

If the browser is targeting an element nested in paper-radio-button (FF and Safari), we get the paper-radio-button element instead. The Select Plan page now works in those browsers.

##### Progress checker

- [X] Polymer

- [ ] Polymer test cases
