### PR TITLE
fixed by refresh for whole report

### DIFF
--- a/polymer/src/elements/ip-reporting/pd-output-list.html
+++ b/polymer/src/elements/ip-reporting/pd-output-list.html
@@ -80,18 +80,48 @@
           statePath: 'programmeDocumentReports.current.loading',
         },
 
-        // pdId
-        // reportId programmeDocumentReports.current.id
-
         data: {
           type: Array,
           statePath: App.Selectors.LLOs.all,
+        },
+
+        reportId: {
+          type: String,
+          statePath: 'programmeDocumentReports.current.id',
+        },
+
+        workspaceId: {
+          type: String,
+          statePath: 'location.id',
+        },
+
+        pdId: {
+          type: Number,
+          statePath: 'programmeDocuments.current',
         },
 
         viewData: {
           type: Array,
           computed: '_computeViewData(data)',
         },
+      },
+
+        listeners: {
+          'refresh-report': '_onRefreshOutput',
+        },
+
+      _onRefreshOutput: function () {
+
+        var ajax = document.createElement('etools-prp-ajax');
+
+        ajax.url = App.Endpoints.programmeDocumentReport(this.workspaceId, this.reportId);
+
+        this.dispatch(
+          App.Actions.PDReports.fetchSingle(ajax.thunk(), this.pdId)
+        )
+            .catch(function (err) { // jshint ignore:line
+              // TODO: error handling
+            });
       },
 
       _computeViewData: function (data) {


### PR DESCRIPTION
Fixed total progress update with refreshing the whole list. It will result in closing all details for indicators. With current structure of responses from backend there doesn't seem a better way to refresh the details for indicators. 