### PR TITLE
Feature - Locking submitted IndicatorLocationData [#651]

### DIFF
--- a/django_api/django_api/apps/indicator/models.py
+++ b/django_api/django_api/apps/indicator/models.py
@@ -22,6 +22,8 @@ from core.common import (
 from core.models import TimeStampedExternalSourceModel
 from functools import reduce
 
+from partner.models import PartnerActivity
+
 from indicator.disaggregators import (
     QuantityIndicatorDisaggregator,
     RatioIndicatorDisaggregator
@@ -710,7 +712,8 @@ def unlock_ild_for_sent_back_cluster_ir(sender, instance, **kwargs):
     Whenever a Cluster indicator report is saved and found to be
     Sent back state then trigger unlock IndicatorLocationData instances.
     """
-    if instance.report_status != INDICATOR_REPORT_STATUS.sent_back:
+    if instance.report_status != INDICATOR_REPORT_STATUS.sent_back \
+            and not isinstance(instance.reportable.content_object, PartnerActivity):
         return
 
     with transaction.atomic():

--- a/django_api/django_api/apps/indicator/models.py
+++ b/django_api/django_api/apps/indicator/models.py
@@ -5,7 +5,7 @@ from django.utils.functional import cached_property
 from django.contrib.postgres.fields import JSONField, ArrayField
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.db import models
+from django.db import models, transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -700,6 +700,24 @@ class IndicatorReport(TimeStampedModel):
                     output_list))
 
         return output_list
+
+
+@receiver(post_save,
+          sender=IndicatorReport,
+          dispatch_uid="unlock_ild_for_sent_back_cluster_ir")
+def unlock_ild_for_sent_back_cluster_ir(sender, instance, **kwargs):
+    """
+    Whenever a Cluster indicator report is saved and found to be
+    Sent back state then trigger unlock IndicatorLocationData instances.
+    """
+    if instance.report_status != INDICATOR_REPORT_STATUS.sent_back:
+        return
+
+    with transaction.atomic():
+        instance.indicator_location_data.all().update(is_locked=False)
+
+        child_irs = instance.children.values_list('id', flat=True)
+        IndicatorLocationData.objects.filter(indicator_report__in=child_irs).update(is_locked=False)
 
 
 @receiver(post_save,

--- a/django_api/django_api/apps/indicator/serializers.py
+++ b/django_api/django_api/apps/indicator/serializers.py
@@ -719,22 +719,6 @@ class IndicatorLocationDataUpdateSerializer(serializers.ModelSerializer):
                     location=self.instance.location,
                 )
 
-                if self.instance.indicator_report:
-                    def get_disagg_lookup_map(ir):
-                        serializer = DisaggregationListSerializer(
-                            ir.disaggregations, many=True)
-
-                        disagg_lookup_list = serializer.data
-                        disagg_lookup_list.sort(key=lambda item: len(item['choices']))
-
-                        return disagg_lookup_list
-
-                    def get_disagg_choice_lookup_map(ir):
-                        lookup_array = ir.disaggregation_values(id_only=False)
-                        lookup_array.sort(key=len)
-
-                        return lookup_array
-
                 split_data = {}
                 disagg_data_copy = copy.deepcopy(data['disaggregation'])
 

--- a/django_api/django_api/apps/indicator/views.py
+++ b/django_api/django_api/apps/indicator/views.py
@@ -598,6 +598,9 @@ class IndicatorLocationDataUpdateAPIView(APIView):
         indicator_location_data = self.get_object(
             request, pk=request.data['id'])
 
+        if indicator_location_data.is_locked:
+            raise ValidationError("This location data is locked to be updated.")
+
         serializer = IndicatorLocationDataUpdateSerializer(
             instance=indicator_location_data, data=request.data)
 

--- a/django_api/django_api/apps/indicator/views.py
+++ b/django_api/django_api/apps/indicator/views.py
@@ -424,6 +424,9 @@ class IndicatorDataAPIView(APIView):
             # IndicatorLocationData lock marking
             IndicatorLocationData.objects.filter(indicator_report=ir).update(is_locked=True)
 
+            child_irs = ir.children.values_list('id', flat=True)
+            IndicatorLocationData.objects.filter(indicator_report__in=child_irs).update(is_locked=True)
+
             serializer = PDReportContextIndicatorReportSerializer(instance=ir)
             return Response(serializer.data, status=status.HTTP_200_OK)
         else:

--- a/django_api/django_api/apps/unicef/views.py
+++ b/django_api/django_api/apps/unicef/views.py
@@ -546,6 +546,9 @@ class ProgressReportSubmitAPIView(APIView):
             ild_ids = progress_report.indicator_reports.values_list('indicator_location_data', flat=True)
             IndicatorLocationData.objects.filter(id__in=ild_ids).update(is_locked=True)
 
+            parent_irs = progress_report.indicator_reports.values_list('parent', flat=True)
+            IndicatorLocationData.objects.filter(indicator_report__in=parent_irs).update(is_locked=True)
+
             serializer = ProgressReportSerializer(instance=progress_report)
             return Response(serializer.data, status=statuses.HTTP_200_OK)
         else:

--- a/polymer/src/elements/indicator-details.html
+++ b/polymer/src/elements/indicator-details.html
@@ -226,7 +226,7 @@
             <div>
               <template
                   is="dom-if"
-                  if="[[!_equals(computedMode, 'view')]]">
+                  if="[[_canEnterData(computedMode, topLevelLocation.byEntity.0.is_locked)]]">
                 <div class="tab-header layout horizontal justified">
                   <div class="self-center">Enter data for this location</div>
                   <div>
@@ -626,6 +626,10 @@
 
       _isDualReportingEnabled: function (entities) {
         return entities.length > 1;
+      },
+
+      _canEnterData: function (mode, isLocked) {
+        return mode !== 'view' && !isLocked;
       },
 
       attached: function () {


### PR DESCRIPTION
### This PR completes #651.

##### Feature list
* _Describe the list of features from Django_
* Django post_save signal to unlock Sent-back Cluster IndicatorReport's IndicatorLocationData instances

* Updates on PD Submit API and Cluster IndicatorReport Submit API to lock IndicatorLocationData instances

* IndicatorLocationDataUpdateAPIView to throw validation error on submitted IndicatorLocationData

* _Describe the list of features from Polymer_

* Hiding Enter Data button if the indicator location data is locked (TBD)

##### Progress checker
- [x] Django

- [ ] Polymer

- [ ] Django test cases

- [ ] Polymer test cases
