### PR TITLE
Fix - X/0 validation logic only for Ratio type

### DIFF
--- a/django_api/django_api/apps/indicator/serializers.py
+++ b/django_api/django_api/apps/indicator/serializers.py
@@ -720,10 +720,11 @@ class IndicatorLocationDataUpdateSerializer(serializers.ModelSerializer):
                 data['disaggregation'][key]['v'] = \
                     int(data['disaggregation'][key]['v'])
 
-            # Checking X/0 data entry case
-            if data['disaggregation'][key]['d'] == 0 and data['disaggregation'][key]['v'] != 0:
+            # Checking X/0 data entry case for ratio type only
+            if data['indicator_report'].reportable.blueprint.unit != IndicatorBlueprint.NUMBER \
+                    and data['disaggregation'][key]['d'] == 0 and data['disaggregation'][key]['v'] != 0:
                 raise serializers.ValidationError(
-                    "Disaggregation key {} has zero denominator and non-zero numerator".format(key)
+                    "Ratio Disaggregation key {} has zero denominator and non-zero numerator".format(key)
                 )
 
         if level_reported_key_count != valid_level_reported_key_count:


### PR DESCRIPTION
### This PR acts as a hot-fix for X/0 location data entry validation.

##### Feature list
* _Describe the list of features from Django_
  * A validation check on a location data's indicator type to throw validation error on ratio type only.

##### Progress checker
- [x] Django