### PR TITLE
Hide save button after report has been submitted

### DIFF
--- a/polymer/src/elements/ip-reporting/pd-report-info.html
+++ b/polymer/src/elements/ip-reporting/pd-report-info.html
@@ -148,9 +148,13 @@
         </div>
 
         <div class="toggle-button-container row">
-          <paper-button class="btn-primary" id="toggle-button" on-tap="_handleInput" raised>
-            Save
-          </paper-button>
+          <template
+              is="dom-if"
+              if="[[!_equals(computeMode, 'view')]]">
+            <paper-button class="btn-primary" id="toggle-button" on-tap="_handleInput" raised>
+              Save
+            </paper-button>
+          </template>
         </div>
 
         <div class="row">


### PR DESCRIPTION
The Save button for the "Other Info" text fields was still being shown after the report had been submitted. I wrapped the button element in a `dom-if` so it will conditionally render as long as the report hasn't been submitted.

##### Feature list
* _Describe the list of features from Polymer_
  * Wrap save button element in a `dom-if` so it only renders if the report hasn't been submitted yet.