### PR TITLE
Add unicef_notifications to handle sending emails

### DIFF
--- a/django_api/django_api/apps/utils/emails.py
+++ b/django_api/django_api/apps/utils/emails.py
@@ -1,11 +1,24 @@
 import logging
 
 from django.conf import settings
-from django.core.mail import EmailMultiAlternatives
-from django.template.loader import render_to_string
-
+from django.template.loader import get_template
+from post_office.models import EmailTemplate
+from unicef_notification.models import Notification
 
 logger = logging.getLogger(__name__)
+
+
+def scrub_template_path(template_path):
+    """Take full template path and generate a template name
+
+    e.g.
+    'email/notify_partner_on_calculation_method_change_subject.txt'
+    ->
+    'notify_partner_on_calculation_method_change_subject'
+    """
+    __, name_ext = template_path.rsplit("/", 1)
+    name, __ = name_ext.split(".", 1)
+    return name
 
 
 def send_email_from_template(
@@ -16,7 +29,6 @@ def send_email_from_template(
         to_email_list=(),
         fail_silently=True,
         content_subtype='plain',
-        **kwargs
 ):
     """
     send_email_from_template simplifies Django's send_email API
@@ -33,15 +45,31 @@ def send_email_from_template(
         fail_silently {bool} -- A flag to mute exception if it fails (default: {True})
     """
 
-    message = EmailMultiAlternatives(
-        render_to_string(subject_template_path, template_data).strip(),
-        render_to_string(body_template_path, template_data),
-        from_email,
-        to_email_list,
-        **kwargs
+    template_name = scrub_template_path(body_template_path)
+    subject_template = get_template(subject_template_path)
+    subject = subject_template.template.source.strip()
+    defaults = {"subject": subject}
+    message = get_template(body_template_path).template.source
+    if content_subtype == "plain":
+        defaults["content"] = message
+    else:
+        defaults["html_content"] = message
+
+    EmailTemplate.objects.update_or_create(
+        name=template_name,
+        defaults=defaults,
     )
-    message.content_subtype = content_subtype
-    message.send(fail_silently=fail_silently)
+    notification = Notification(
+        method_type=Notification.TYPE_EMAIL,
+        sender=None,
+        from_address=from_email,
+        recipients=to_email_list,
+        template_name=template_name,
+        template_data=template_data,
+    )
+    notification.full_clean()
+    notification.save()
+    notification.send_notification()
 
 
 def send_due_progress_report_email():

--- a/django_api/django_api/settings/base.py
+++ b/django_api/django_api/settings/base.py
@@ -123,6 +123,8 @@ INSTALLED_APPS = [
     'unicef',
     'ocha',
     'id_management',
+    'post_office',
+    'unicef_notification',
 ]
 
 MIDDLEWARE_CLASSES = [

--- a/django_api/requirements/base.txt
+++ b/django_api/requirements/base.txt
@@ -30,6 +30,7 @@ Babel==2.5.3
 pycountry==18.2.23
 aiohttp==3.0.8
 pyrestcli==0.6.6
+unicef-notification==0.2.1
 
 # Storages
 boto3==1.7.0


### PR DESCRIPTION
### This PR completes #11196

Added unicef_notifications library.

Attempting to handle the current email templates, con is that each time email sent templates are checked for changes and updates the notification record.