### PR TITLE
Revert "Add unicef_notifications to handle sending emails"

### DIFF
--- a/django_api/django_api/apps/unicef/tests/test_models.py
+++ b/django_api/django_api/apps/unicef/tests/test_models.py
@@ -1,8 +1,8 @@
 from datetime import date
 from dateutil.relativedelta import relativedelta
 
+from django.core import mail
 from django.db.models import Q
-from unicef_notification.models import Notification
 
 from core.common import (
     INDICATOR_REPORT_STATUS,
@@ -252,6 +252,7 @@ class TestProgressReportModel(BaseAPITestCase):
         return ProgressReport.objects.filter(programme_document_id__in=pd_ids)
 
     def test_send_notification_on_status_change_post_save_signal_for_submitted(self):
+        mail.outbox = []
         report = ProgressReport.objects.get(report_type="QPR", report_number=1)
         report.status = PROGRESS_REPORT_STATUS.due
         report.save()
@@ -260,13 +261,14 @@ class TestProgressReportModel(BaseAPITestCase):
         report.save()
 
         # Match # of emails sent by submitting_user (also identical to submitted_by), and unicef_focal_point
-        self.assertEqual(Notification.objects.count(), 4)
+        self.assertEqual(len(mail.outbox), 2)
 
-        sent_mail = Notification.objects.last().sent_email
+        sent_mail = mail.outbox[-1]
 
-        self.assertIn("Please note that the following was submitted to UNICEF:", sent_mail.html_message)
+        self.assertIn("Please note that the following was submitted to UNICEF:", sent_mail.body)
 
     def test_send_notification_on_status_change_post_save_signal_for_sent_back(self):
+        mail.outbox = []
         report = ProgressReport.objects.get(report_type="QPR", report_number=1)
         report.status = PROGRESS_REPORT_STATUS.due
         report.save()
@@ -275,16 +277,17 @@ class TestProgressReportModel(BaseAPITestCase):
         report.save()
 
         # Match # of emails sent by submitting_user (also identical to submitted_by), and unicef_focal_point
-        self.assertEqual(Notification.objects.count(), 4)
+        self.assertEqual(len(mail.outbox), 2)
 
-        sent_mail = Notification.objects.last().sent_email
+        sent_mail = mail.outbox[-1]
 
-        self.assertIn("Please note that the following was sent back by UNICEF:", sent_mail.html_message)
+        self.assertIn("Please note that the following was sent back by UNICEF:", sent_mail.body)
         self.assertIn(
             "Please log in to the UNICEF Partner Reporting Portal to see the reason "
-            + "and contact details of the person that sent the report back.", sent_mail.html_message)
+            + "and contact details of the person that sent the report back.", sent_mail.body)
 
     def test_send_notification_on_status_change_post_save_signal_for_accepted(self):
+        mail.outbox = []
         report = ProgressReport.objects.get(report_type="QPR", report_number=1)
         report.status = PROGRESS_REPORT_STATUS.due
         report.save()
@@ -293,13 +296,14 @@ class TestProgressReportModel(BaseAPITestCase):
         report.save()
 
         # Match # of emails sent by submitting_user (also identical to submitted_by), and unicef_focal_point
-        self.assertEqual(Notification.objects.count(), 4)
+        self.assertEqual(len(mail.outbox), 2)
 
-        sent_mail = Notification.objects.last().sent_email
+        sent_mail = mail.outbox[-1]
 
-        self.assertIn("Please note that the following was accepted by UNICEF:", sent_mail.html_message)
+        self.assertIn("Please note that the following was accepted by UNICEF:", sent_mail.body)
 
     def test_send_due_progress_report_email(self):
+        mail.outbox = []
         today = date.today()
 
         report = ProgressReport.objects.get(report_type="QPR", report_number=1)
@@ -311,17 +315,14 @@ class TestProgressReportModel(BaseAPITestCase):
         send_due_progress_report_email()
 
         # Match # of emails sent by unicef_officer and unicef_focal_point
-        self.assertEqual(Notification.objects.count(), 4)
+        self.assertEqual(len(mail.outbox), 2)
 
-        sent_mail = Notification.objects.last().sent_email
-        print(sent_mail.pk)
+        sent_mail = mail.outbox[-1]
 
-        self.assertIn(
-            "Please note that the following is due in 1 week:",
-            sent_mail.html_message,
-        )
+        self.assertIn("Please note that the following is due in 1 week:", sent_mail.body)
 
     def test_send_overdue_progress_report_email(self):
+        mail.outbox = []
         today = date.today()
 
         report = ProgressReport.objects.get(report_type="QPR", report_number=1)
@@ -333,8 +334,8 @@ class TestProgressReportModel(BaseAPITestCase):
         send_overdue_progress_report_email()
 
         # Match # of emails sent by unicef_officer and unicef_focal_point
-        self.assertEqual(Notification.objects.count(), 4)
+        self.assertEqual(len(mail.outbox), 2)
 
-        sent_mail = Notification.objects.last().sent_email
+        sent_mail = mail.outbox[-1]
 
-        self.assertIn("Please note that the following is overdue:", sent_mail.html_message)
+        self.assertIn("Please note that the following is overdue:", sent_mail.body)

--- a/django_api/django_api/settings/base.py
+++ b/django_api/django_api/settings/base.py
@@ -123,8 +123,6 @@ INSTALLED_APPS = [
     'unicef',
     'ocha',
     'id_management',
-    'post_office',
-    'unicef_notification',
 ]
 
 MIDDLEWARE_CLASSES = [

--- a/django_api/requirements/base.txt
+++ b/django_api/requirements/base.txt
@@ -30,7 +30,6 @@ Babel==2.5.3
 pycountry==18.2.23
 aiohttp==3.0.8
 pyrestcli==0.6.6
-unicef-notification==0.2.1
 
 # Storages
 boto3==1.7.0


### PR DESCRIPTION
Django unit tests are failing due to dependency to redis. Either mock it or modify unit test cases to avoid this dependency.