### PR TITLE
Update notification tests to mock email sending

### DIFF
--- a/django_api/django_api/apps/cluster/tests/test_views.py
+++ b/django_api/django_api/apps/cluster/tests/test_views.py
@@ -1,5 +1,6 @@
 import datetime
 from dateutil.relativedelta import relativedelta
+from unittest.mock import Mock, patch
 
 from django.urls import reverse
 
@@ -719,20 +720,21 @@ class IndicatorReportsListAPIViewTestCase(BaseAPITestCase):
         )
 
         # Create 4 indicator reports across generic relation
-        self.clusteractivity_indicator_report = ClusterIndicatorReportFactory(
-            reportable=self.clusteractivity_reportable,
-        )
-        self.partneractivity_indicator_report = ClusterIndicatorReportFactory(
-            reportable=self.partneractivity_reportable,
-            report_status=INDICATOR_REPORT_STATUS.submitted,
-        )
-        self.clusterobjective_indicator_report = ClusterIndicatorReportFactory(
-            reportable=self.clusterobjective_reportable,
-            report_status=INDICATOR_REPORT_STATUS.overdue,
-        )
-        self.partnerproject_indicator_report = ClusterIndicatorReportFactory(
-            reportable=self.partnerproject_reportable,
-        )
+        with patch("django.db.models.signals.ModelSignal.send", Mock()):
+            self.clusteractivity_indicator_report = ClusterIndicatorReportFactory(
+                reportable=self.clusteractivity_reportable,
+            )
+            self.partneractivity_indicator_report = ClusterIndicatorReportFactory(
+                reportable=self.partneractivity_reportable,
+                report_status=INDICATOR_REPORT_STATUS.submitted,
+            )
+            self.clusterobjective_indicator_report = ClusterIndicatorReportFactory(
+                reportable=self.clusterobjective_reportable,
+                report_status=INDICATOR_REPORT_STATUS.overdue,
+            )
+            self.partnerproject_indicator_report = ClusterIndicatorReportFactory(
+                reportable=self.partnerproject_reportable,
+            )
 
         self.loc_data = IndicatorLocationDataFactory(
             indicator_report=self.partnerproject_indicator_report,
@@ -887,24 +889,25 @@ class IndicatorReportDetailAPIViewTestCase(BaseAPITestCase):
         )
 
         # Create 4 indicator reports across generic relation
-        self.clusteractivity_indicator_report = ClusterIndicatorReportFactory(
-            reportable=self.clusteractivity_reportable,
-        )
-        self.partneractivity_indicator_report = ClusterIndicatorReportFactory(
-            reportable=self.partneractivity_reportable,
-            report_status=INDICATOR_REPORT_STATUS.submitted,
-        )
-        self.custom_partneractivity_indicator_report = ClusterIndicatorReportFactory(
-            reportable=self.custom_partneractivity_reportable,
-            report_status=INDICATOR_REPORT_STATUS.submitted,
-        )
-        self.clusterobjective_indicator_report = ClusterIndicatorReportFactory(
-            reportable=self.clusterobjective_reportable,
-            report_status=INDICATOR_REPORT_STATUS.overdue,
-        )
-        self.partnerproject_indicator_report = ClusterIndicatorReportFactory(
-            reportable=self.partnerproject_reportable,
-        )
+        with patch("django.db.models.signals.ModelSignal.send", Mock()):
+            self.clusteractivity_indicator_report = ClusterIndicatorReportFactory(
+                reportable=self.clusteractivity_reportable,
+            )
+            self.partneractivity_indicator_report = ClusterIndicatorReportFactory(
+                reportable=self.partneractivity_reportable,
+                report_status=INDICATOR_REPORT_STATUS.submitted,
+            )
+            self.custom_partneractivity_indicator_report = ClusterIndicatorReportFactory(
+                reportable=self.custom_partneractivity_reportable,
+                report_status=INDICATOR_REPORT_STATUS.submitted,
+            )
+            self.clusterobjective_indicator_report = ClusterIndicatorReportFactory(
+                reportable=self.clusterobjective_reportable,
+                report_status=INDICATOR_REPORT_STATUS.overdue,
+            )
+            self.partnerproject_indicator_report = ClusterIndicatorReportFactory(
+                reportable=self.partnerproject_reportable,
+            )
 
         self.clusteractivity_loc_data = IndicatorLocationDataFactory(
             indicator_report=self.clusteractivity_indicator_report,

--- a/django_api/django_api/apps/indicator/tests/test_views.py
+++ b/django_api/django_api/apps/indicator/tests/test_views.py
@@ -1,11 +1,13 @@
 from ast import literal_eval as make_tuple
 import copy
 from datetime import date, timedelta
+from unittest.mock import Mock, patch
 
 from django.urls import reverse
 from django.conf import settings
 
 from rest_framework import status
+from unicef_notification.models import Notification
 
 from core.models import Location
 from core.common import (
@@ -325,7 +327,10 @@ class TestIndicatorDataAPIView(BaseAPITestCase):
 
         super().setUp()
 
-    def test_submit_indicator(self):
+    @patch("django_api.apps.utils.emails.EmailTemplate.objects.update_or_create")
+    @patch.object(Notification, "full_clean", return_value=None)
+    @patch.object(Notification, "send_notification", return_value=None)
+    def test_submit_indicator(self, mock_create, mock_clean, mock_send):
         ir = IndicatorReport.objects.first()
         ir.report_status = INDICATOR_REPORT_STATUS.sent_back
         ir.overall_status = OVERALL_STATUS.met
@@ -840,10 +845,11 @@ class TestIndicatorReportListAPIView(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")
@@ -1043,10 +1049,11 @@ class TestClusterIndicatorAPIView(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")
@@ -1473,10 +1480,11 @@ class TestIndicatorLocationDataUpdateAPIView(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")
@@ -2019,10 +2027,11 @@ class TestReportRefreshAPIView(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")

--- a/django_api/django_api/apps/ocha/tests.py
+++ b/django_api/django_api/apps/ocha/tests.py
@@ -1,5 +1,7 @@
 import json
 import os
+from unittest.mock import Mock, patch
+
 from django.test import TestCase
 from django.conf import settings
 
@@ -206,10 +208,11 @@ class V2PartnerProjectSerializerTest(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")
@@ -405,10 +408,11 @@ class V1ResponsePlanImportSerializerTest(TestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")

--- a/django_api/django_api/apps/partner/tests/test_views.py
+++ b/django_api/django_api/apps/partner/tests/test_views.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import Mock, patch
 
 from django.conf import settings
 from django.urls import reverse
@@ -207,10 +208,11 @@ class TestPartnerProjectListCreateAPIView(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")
@@ -475,10 +477,11 @@ class TestPartnerProjectAPIView(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")
@@ -790,10 +793,11 @@ class TestCustomPartnerProjectAPIView(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")

--- a/django_api/django_api/apps/unicef/tests/test_models.py
+++ b/django_api/django_api/apps/unicef/tests/test_models.py
@@ -46,7 +46,7 @@ from core.factories import (CartoDBTableFactory,
                             ClusterIndicatorReportFactory)
 from core.tests.base import BaseAPITestCase
 from core.models import Location
-from utils.emails import send_due_progress_report_email, send_overdue_progress_report_email
+from utils.emails import send_due_progress_report_email
 from indicator.disaggregators import QuantityIndicatorDisaggregator
 from indicator.models import (
     IndicatorBlueprint,

--- a/django_api/django_api/apps/unicef/tests/test_views.py
+++ b/django_api/django_api/apps/unicef/tests/test_views.py
@@ -1,6 +1,7 @@
 import datetime
 import tempfile
 import os
+from unittest.mock import Mock, patch
 
 from django.conf import settings
 from django.core.files import File
@@ -205,10 +206,11 @@ class TestProgrammeDocumentListAPIView(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")
@@ -459,10 +461,11 @@ class TestProgrammeDocumentDetailAPIView(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")
@@ -668,10 +671,11 @@ class TestProgressReportAPIView(BaseAPITestCase):
         )
 
         for _ in range(2):
-            ClusterIndicatorReportFactory(
-                reportable=self.partneractivity_reportable,
-                report_status=INDICATOR_REPORT_STATUS.submitted,
-            )
+            with patch("django.db.models.signals.ModelSignal.send", Mock()):
+                ClusterIndicatorReportFactory(
+                    reportable=self.partneractivity_reportable,
+                    report_status=INDICATOR_REPORT_STATUS.submitted,
+                )
 
         # Creating Level-3 disaggregation location data for all locations
         generate_3_num_disagg_data(self.partneractivity_reportable, indicator_type="quantity")


### PR DESCRIPTION
### This PR completes #11196

Update tests to mock the actual sending of emails, to prevent calls to redis