### PR TITLE
Fix location dropdown

### DIFF
--- a/polymer/src/elements/cluster-reporting/indicator-locations-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-locations-modal.html
@@ -303,7 +303,7 @@
       },
 
       _getLocationName: function (locationId, locations) {
-        var location = locations.find(function (loc) {
+        var location = locations.results.find(function (loc) {
           return String(loc.id) === String(locationId);
         });
 

--- a/polymer/src/elements/cluster-reporting/indicator-locations-widget.html
+++ b/polymer/src/elements/cluster-reporting/indicator-locations-widget.html
@@ -225,7 +225,7 @@
                   options="[[_getLocations(locations, item.loc_type)]]"
                   option-value="id"
                   option-label="title"
-                  selected="{{item.location}}"
+                  selected="[[item.location]]"
                   on-value-changed="_onValueChanged"
                   data-index$="[[index]]"
                   disabled="[[_getPending(pending, item.loc_type)]]"
@@ -335,6 +335,11 @@
             value: false,
           },
 
+          locationsInitialized: {
+            type: Boolean,
+            value: false
+          },
+
           maxAdminLevel: {
             type: Number,
             value: App.Settings.cluster.maxLocType,
@@ -377,7 +382,7 @@
           this.debounce('fetch-locations-' + loc_type, function() {
             var self = this;
 
-            if (event.detail.value === '') {
+            if (this.locationsInitialized === false) {
               this.$$('#locations' + loc_type).thunk()()
                 .then(function (res) {
                   self.set('url', res.xhr.responseURL);
@@ -387,25 +392,34 @@
                 .catch(function () {
                   self._setPending(loc_type, false);
                 });
-              return;
-            } else {
-              var thunk = self.$.search;
-              thunk.url = self.get('url');
-
-              thunk.params = {
-                loc_type: loc_type,
-                title: event.detail.value
-              };
-
-              thunk.thunk()()
-                .then(function(res) {
-                  self._setLocations(loc_type, res.data.results);
-                })
-                .catch(function (err) {
-                  console.log(err);
-                  self._setPending(loc_type, false);
-                });
+              
+              this.set('locationsInitialized', true);
             }
+
+            if (event.detail.value === '') {
+              return;
+            }
+
+            var thunk = self.$.search;
+            thunk.url = self.get('url');
+
+            console.log('event changed', event);
+
+            thunk.params = {
+              loc_type: loc_type,
+              title: event.detail.value
+            };
+
+            thunk.thunk()()
+              .then(function(res) {
+                self._setPending(loc_type, false);
+                self._setLocations(loc_type, res.data.results);
+              })
+              .catch(function (err) {
+                console.log(err);
+                self._setPending(loc_type, false);
+              });
+            return;
           }, 1000);
         },
 
@@ -496,6 +510,7 @@
             return;
           }
           this.set('searchLocationType', loc_type);
+          console.log('do we get here?');
 
           this.debounce('fetch-locations-' + loc_type, function () {
             var self = this;
@@ -547,6 +562,7 @@
         },
 
         _setLocations: function (loc_type, value) {
+          console.log('here again?');
           var newLocations = Object.assign({}, this.get('locations'));
 
           newLocations[loc_type] = value;

--- a/polymer/src/elements/cluster-reporting/indicator-locations-widget.html
+++ b/polymer/src/elements/cluster-reporting/indicator-locations-widget.html
@@ -225,7 +225,7 @@
                   options="[[_getLocations(locations, item.loc_type)]]"
                   option-value="id"
                   option-label="title"
-                  selected="[[item.location]]"
+                  selected="{{item.location}}"
                   on-value-changed="_onValueChanged"
                   data-index$="[[index]]"
                   disabled="[[_getPending(pending, item.loc_type)]]"
@@ -403,8 +403,6 @@
             var thunk = self.$.search;
             thunk.url = self.get('url');
 
-            console.log('event changed', event);
-
             thunk.params = {
               loc_type: loc_type,
               title: event.detail.value
@@ -510,7 +508,6 @@
             return;
           }
           this.set('searchLocationType', loc_type);
-          console.log('do we get here?');
 
           this.debounce('fetch-locations-' + loc_type, function () {
             var self = this;
@@ -562,7 +559,6 @@
         },
 
         _setLocations: function (loc_type, value) {
-          console.log('here again?');
           var newLocations = Object.assign({}, this.get('locations'));
 
           newLocations[loc_type] = value;


### PR DESCRIPTION
### This PR fixes an issue with the location dropdown component.

If the user used the search functionality of the location dropdown, selected a location, then continued filling out the form, the onValueChanged event would fire again (because by selecting a location, the value would change from whatever search value the user put in back to an empty string), clearing out the user selection.

Also, there was an issue with the Locations button in Cluster Activity Indicator not working. This was because the locations array was now inside a `results` property in a larger object, so it was just a matter of changing `locations.find()` to `locations.results.find()`.

##### Feature list
* _Describe the list of features from Polymer_
  * Added a guard clause to simply not make an API call if the search string is empty
  * Added an additional guard clause to make the API call once, in order to populate the locations of the first loc_type
  * Changed `_getLocationName` method to correctly target locations array in `results` property of object being brought back

##### Progress checker
- [ ] Polymer

- [ ] Polymer test cases
