### PR TITLE
fix: Update webpack-dev-server version to resolve security vulnerability

### DIFF
--- a/react/id_management_frontend/package.json
+++ b/react/id_management_frontend/package.json
@@ -74,7 +74,7 @@
     "url-loader": "0.6.2",
     "url-parse": "1.4.3",
     "webpack": "3.8.1",
-    "webpack-dev-server": "3.0.0",
+    "webpack-dev-server": "3.1.11",
     "webpack-manifest-plugin": "1.3.2",
     "whatwg-fetch": "2.0.3"
   },


### PR DESCRIPTION
Needed to update `webpack-dev-server` version to 3.1.11 to resolve security vulnerability.

##### Feature list
* _Describe the list of features from Polymer_
  * Updated `webpack-dev-server` from `package.json` to 3.1.11

##### Progress checker
- [ ] Polymer

- [ ] Polymer test cases
