### PR TITLE
[ch11490] Have input character counters update dynamically

### DIFF
--- a/polymer/src/elements/ip-reporting/pd-report-info.html
+++ b/polymer/src/elements/ip-reporting/pd-report-info.html
@@ -87,14 +87,13 @@
                 is="dom-if"
                 if="[[!_equals(computedMode, 'view')]]"
                 restamp="true">
-              <paper-input-container
-                  no-label-float>
-                <input
-                    id="partner_contribution_to_date"
-                    value="[[data.partner_contribution_to_date]]"
-                    maxlength="2000">
-                <paper-input-char-counter></paper-input-char-counter>
-              </paper-input-container>
+              <paper-input
+                  id="partner_contribution_to_date"
+                  value="[[data.partner_contribution_to_date]]"
+                  no-label-float
+                  char-counter
+                  maxlength="2000">
+              </paper-input>
             </template>
           </labelled-item>
         </div>
@@ -112,14 +111,13 @@
                 is="dom-if"
                 if="[[!_equals(computedMode, 'view')]]"
                 restamp="true">
-              <paper-input-container
-                  no-label-float>
-                <input
-                    id="challenges_in_the_reporting_period"
-                    value="[[data.challenges_in_the_reporting_period]]"
-                    maxlength="2000">
-                <paper-input-char-counter></paper-input-char-counter>
-              </paper-input-container>
+              <paper-input
+                  id="challenges_in_the_reporting_period"
+                  value="[[data.challenges_in_the_reporting_period]]"
+                  no-label-float
+                  char-counter
+                  maxlength="2000">
+              </paper-input>
             </template>
           </labelled-item>
         </div>
@@ -137,14 +135,13 @@
                 is="dom-if"
                 if="[[!_equals(computedMode, 'view')]]"
                 restamp="true">
-               <paper-input-container
-                  no-label-float>
-                <input
-                    id="proposed_way_forward"
-                    value="[[data.proposed_way_forward]]"
-                    maxlength="2000">
-                <paper-input-char-counter></paper-input-char-counter>
-              </paper-input-container>
+              <paper-input
+                  id="proposed_way_forward"
+                  value="[[data.proposed_way_forward]]"
+                  no-label-float
+                  char-counter
+                  maxlength="2000">
+              </paper-input>
             </template>
           </labelled-item>
         </div>
@@ -235,12 +232,10 @@
 
       _handleInput: function () {
         var self = this;
-        var textInputs = Polymer.dom(this.root).querySelectorAll('labelled-item');
+        var textInputs = Polymer.dom(this.root).querySelectorAll('paper-input');
 
         textInputs.forEach(function (input) {
-          var field = input.querySelector('input');
-
-          self.set(['localData', field.id], field.value.trim());
+          self.set(['localData', input.id], input.$.input.value.trim());
         });
       },
 

--- a/polymer/src/elements/reportable-meta.html
+++ b/polymer/src/elements/reportable-meta.html
@@ -1,8 +1,6 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../../bower_components/paper-radio-button/paper-radio-button.html">
-<link rel="import" href="../../bower_components/paper-input/paper-input-container.html">
-<link rel="import" href="../../bower_components/paper-input/paper-input-char-counter.html">
 <link rel="import" href="../../bower_components/paper-input/paper-input.html">
 
 <link rel="import" href="../behaviors/utils.html">
@@ -17,6 +15,11 @@
     <style include="button-styles">
       :host {
         display: block;
+
+        --paper-input-container-disabled: {
+          opacity: 0.67
+        };
+
       }
 
       labelled-item {
@@ -34,7 +37,7 @@
         flex-direction: row;
       }
 
-      paper-input-container {
+      paper-input {
         width: 100%;
         padding-right: 18px;
       }
@@ -114,15 +117,14 @@
           if="[[!_equals(mode, 'view')]]"
           restamp="true">
         <div id="input-button-container">
-          <paper-input-container
-              no-label-float>
-            <input
-                id="narrative_assessment"
-                value="[[data.narrative_assessment]]"
-                disabled
-                maxlength="2000">
-            <paper-input-char-counter></paper-input-char-counter>
-          </paper-input-container>
+          <paper-input
+              id="narrative_assessment"
+              value="[[data.narrative_assessment]]"
+              disabled
+              char-counter
+              no-label-float
+              maxlength="2000">
+          </paper-input>
           <paper-button class="btn-primary" id="toggle-button" on-tap="_handleInput" raised>
             {{toggle}}
           </paper-button>
@@ -200,17 +202,9 @@
         },
       },
 
-      _updateCharCounter: function (event) {
-        console.log('event', event);
-        var input = this.$$('#narrative_assessment');
-        var inputContainer = input.parentElement;
-        var charCounter = input.nextElementSibling;
-        console.log('input', charCounter.update(inputContainer));
-      },
-
       _handleInput: function () {
         var field = Polymer.dom(event).rootTarget;
-        var narrativeTextInput = Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('input');
+        var narrativeTextInput = this.$$('#narrative_assessment');
 
         if (field.textContent.trim() === 'Edit') {
           narrativeTextInput.disabled = false;
@@ -224,7 +218,7 @@
             return node.label === 'Narrative assessment';
           });
 
-          field = parent.querySelector('paper-input-container').querySelector('input');
+          field = parent.querySelector('paper-input');
         }
 
         var id = field.id;
@@ -292,7 +286,7 @@
 
       detached: function () {
         this.set(['localData', 'narrative_assessment'],
-          Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('input').value);
+          Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input').value);
         
         if (this.isDebouncerActive('local-data-changed')) {
           this.cancelDebouncer('local-data-changed');

--- a/polymer/src/elements/reportable-meta.html
+++ b/polymer/src/elements/reportable-meta.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../../bower_components/paper-radio-button/paper-radio-button.html">
 <link rel="import" href="../../bower_components/paper-input/paper-input-container.html">
 <link rel="import" href="../../bower_components/paper-input/paper-input-char-counter.html">
+<link rel="import" href="../../bower_components/paper-input/paper-input.html">
 
 <link rel="import" href="../behaviors/utils.html">
 <link rel="import" href="report-status.html">
@@ -197,6 +198,14 @@
             return App.Endpoints.reportProgressReset();
           },
         },
+      },
+
+      _updateCharCounter: function (event) {
+        console.log('event', event);
+        var input = this.$$('#narrative_assessment');
+        var inputContainer = input.parentElement;
+        var charCounter = input.nextElementSibling;
+        console.log('input', charCounter.update(inputContainer));
       },
 
       _handleInput: function () {


### PR DESCRIPTION
### This PR completes part of bug ticket #ch11490. 

##### Feature list
* _Describe the list of features from Polymer_
  * The character counters for the narrative assessment field and the three fields in the Other Info tab would only update when they became unfocused. I changed them to use Polymer's `paper-input` components with their built-in character counters, rather than use `input` elements with the `paper-input-char-counter` component.

##### Progress checker
- [ ] Polymer

- [ ] Polymer test cases
