### PR TITLE
[ch12052] Add "Adopt from Cluster Activity" option to Add Partner Activity Indicator modal

### DIFF
--- a/polymer/src/elements/cluster-reporting/indicator-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-modal.html
@@ -1372,8 +1372,6 @@
               return indicator.id === selectedIndicator;
             });
 
-            console.log('indicator', chosenActivityIndicator);
-
             this.set('data.blueprint.title', chosenActivityIndicator.title);
             this.set('data.frequency', chosenActivityIndicator.frequency);
             this.set('data.label', chosenActivityIndicator.label);
@@ -1386,7 +1384,6 @@
           this.$.indicatorDetail.thunk()()
             .then(function (res) {
               self.set('selectedIndicatorDetailType', res.data.display_type);
-              console.log('data right now', self.data);
             })
             .catch(function (err) { // jshint ignore:line
               // TODO: error handling

--- a/polymer/src/elements/cluster-reporting/indicator-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-modal.html
@@ -122,6 +122,12 @@
     </etools-prp-ajax>
 
     <etools-prp-ajax
+      id="activities"
+      params="[[activitiesParams]]"
+      url="[[activitiesUrl]]">
+  </etools-prp-ajax>
+
+    <etools-prp-ajax
       id="indicators"
       url="[[indicatorsUrl]]"
       method="post"
@@ -338,13 +344,13 @@
                             options="[[activities]]"
                             option-value="id"
                             option-label="title"
-                            selected="{{ selectedActivity }}"
+                            selected="{{ data.cluster_activity_id }}"
                             on-iron-select="_validate"
                             disabled="[[_equals(activities.length, 0)]]"
                             required>
                         </etools-single-selection-menu>
                       </div>
-    
+
                       <div class="item full-width">
                         <etools-single-selection-menu
                           class="validate"
@@ -943,6 +949,20 @@
           value: {},
         },
 
+        activitiesUrl: String,
+
+        activitiesParams: {
+          type: Object,
+          value: {
+            page_size: 99999,
+          },
+        },
+
+        activities: {
+          type: Array,
+          value: [],
+        },
+
         clusters: {
           format: Array,
           value: [],
@@ -1066,8 +1086,10 @@
         '_resetFields(isNumber)',
         '_updateCSDates(data.start_date_of_reporting_period)',
         '_saveCluster(selectedCluster)',
+        '_fetchActivities(selectedCluster)',
         '_fetchObjectivesList(selectedCluster)',
         '_fetchIndicatorsList(selectedObjective)',
+        '_fetchActivityIndicatorsList(data.cluster_activity_id)',
         '_fetchSelectedIndicatorDetailType(responsePlanId, selectedIndicator)',
       ],
 
@@ -1155,6 +1177,19 @@
           });
 
           this.set('indicatorsUrl', App.Endpoints.adoptedClusterIndicators());
+        } else if (this.mode === 'activity') {
+          this.set('data', {
+            partner_id: this.activityData.partner.id || this.partnerID,
+            partner_project_id: '',
+            cluster_id: '',
+            cluster_activity_id: '',
+            reportable_id: '',
+            locations: [],
+            target: {d: 1},
+            baseline: {d: 1}
+          });
+
+          this.set('indicatorsListUrl', App.Endpoints.indicators('ca') + '/');
         } else {
           this.set('selectedDisaggregations', []);
           this.set('errors', {});
@@ -1210,6 +1245,60 @@
 
       _saveCluster: function () {
         this.set('data.cluster_id', this.selectedCluster);
+      },
+
+      _fetchActivities: function (clusterId) {
+        var self = this;
+        if (typeof clusterId === 'undefined' || typeof this.responsePlanId === 'undefined') {
+          return;
+        }
+        this.set('activities', []);
+        this.set('data.cluster.cluster_activity', undefined);
+        this.set('activitiesParams.cluster_id', clusterId);
+        this.set('activitiesUrl',
+            App.Endpoints.responseParametersClusterActivities(this.responsePlanId)
+            + '?cluster_id=' + clusterId);
+        this.$.activities.abort();
+
+        this.$.activities.thunk()()
+            .then(function (res) {
+              self.set('activities', res.data.results);
+            })
+            .catch(function (err) { // jshint ignore:line
+              // TODO: error handling
+            });
+      },
+
+      _fetchActivityIndicatorsList: function (selectedId) {
+        if (selectedId === '') {
+          return;
+        }
+
+        this.set('indicatorsListParams', {object_id: selectedId, page_size: 9999, page: 1});
+
+        this.debounce('fetch-indicators', function () {
+          var self = this;
+
+          this.set('indicators', []);
+
+          this.$.indicatorsList.abort();
+          this.$.indicatorsList.thunk()()
+            .then(function (res) {
+              console.log('res', res);
+              var simpleIndicatorsList = [];
+
+              res.data.results.forEach(function (indicator) {
+                var simpleIndicator = {};
+                simpleIndicator.id = indicator.id;
+                simpleIndicator.title = indicator.blueprint.title;
+
+                simpleIndicatorsList.push(simpleIndicator);
+              });
+
+              self.set('indicators', simpleIndicatorsList);
+              self.fire('details-loaded');
+            });
+        });
       },
 
       _fetchObjectivesList: function (selectedClusterId) {

--- a/polymer/src/elements/cluster-reporting/indicator-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-modal.html
@@ -130,12 +130,6 @@
     </etools-prp-ajax>
 
     <etools-prp-ajax
-      id="partners"
-      timeout="100000"
-      url="[[partnersUrl]]">
-    </etools-prp-ajax>
-
-    <etools-prp-ajax
       id="objectives"
       timeout="100000"
       url="[[objectivesUrl]]"
@@ -187,117 +181,221 @@
               selected="{{ mode }}"
               on-change="adjustPosition">
   
-              <paper-radio-button name="objectives">
-                <strong>Adopt from Cluster Objective</strong>
-              </paper-radio-button>
-  
-              <div
-                class="fields"
-                empty$="[[!_equals(mode, 'objectives')]]">
-                <template
-                  is="dom-if"
-                  if="[[_equals(mode, 'objectives')]]"
-                  restamp="true">
-                  
-                  <div class="app-grid">
-                    <div class="item full-width">
-                      <template
-                        is="dom-if"
-                        if="[[imoInPartner]]"
-                        restamp="true">
+              <template
+                is="dom-if"
+                if="[[!_equals(modalTitle, 'Add Activity Indicator')]]"
+                restamp="true">
 
+                <paper-radio-button name="objectives">
+                  <strong>Adopt from Cluster Objective</strong>
+                </paper-radio-button>
+    
+                <div
+                  class="fields"
+                  empty$="[[!_equals(mode, 'objectives')]]">
+                  <template
+                    is="dom-if"
+                    if="[[_equals(mode, 'objectives')]]"
+                    restamp="true">
+                    
+                    <div class="app-grid">
+                      <div class="item full-width">
+                        <template
+                          is="dom-if"
+                          if="[[imoInPartner]]"
+                          restamp="true">
+  
+                          <etools-single-selection-menu
+                            class="validate"
+                            label="Partners *"
+                            options="[[partners]]"
+                            option-value="id"
+                            option-label="title"
+                            selected="{{ selectedPartner }}"
+                            on-iron-activate="_validate"
+                            required>
+                          </etools-single-selection-menu>
+                        </template>
+                      </div>
+  
+                      <div class="item">
                         <etools-single-selection-menu
+                          id="clustersDropdown"
                           class="validate"
-                          label="Partners *"
-                          options="[[partners]]"
+                          label="Clusters *"
+                          options="[[clusters]]"
                           option-value="id"
                           option-label="title"
-                          selected="{{ selectedPartner }}"
+                          selected="{{ selectedCluster }}"
+                          on-iron-activate="_validate"
+                          disabled="[[_equals(selectedPartner, '')]]"
+                          required>
+                        </etools-single-selection-menu>
+                      </div>
+    
+                      <div class="item">
+                        <etools-single-selection-menu
+                            class="validate"
+                            label="Objective *"
+                            options="[[objectives]]"
+                            option-value="id"
+                            option-label="title"
+                            selected="{{ selectedObjective }}"
+                            on-iron-select="_validate"
+                            disabled="[[_equals(objectives.length, 0)]]"
+                            required>
+                        </etools-single-selection-menu>
+                      </div>
+    
+                      <div class="item full-width">
+                        <etools-single-selection-menu
+                          class="validate"
+                          label="Indicator *"
+                          options="[[indicators]]"
+                          option-value="id"
+                          option-label="title"
+                          selected="{{ selectedIndicator }}"
+                          on-iron-select="_validate"
+                          disabled="[[_equals(indicators.length, 0)]]"
+                          required>
+                        </etools-single-selection-menu>
+                      </div>
+    
+                      <json-field
+                        class="item validate"
+                        id="target"
+                        label="Baseline"
+                        value="{{ data.baseline }}"
+                        type="[[selectedIndicatorDetailType]]"
+                        allowed-pattern="[+\-\d.]"
+                        on-input="_validate">
+                      </json-field>
+    
+                      <json-field
+                        class="item validate"
+                        id="total"
+                        label="Target"
+                        value="{{ data.target }}"
+                        type="[[selectedIndicatorDetailType]]"
+                        allowed-pattern="[+\-\d.]"
+                        on-input="_validate">
+                      </json-field>
+    
+                      <template
+                        is="dom-if"
+                        if="[[selectedIndicatorDetailType]]"
+                        restamp="true">
+                        <div class="item full-width">
+                          <indicator-locations-widget
+                            class="validate"
+                            indicator-type="[[selectedIndicatorDetailType]]"
+                            value="{{ data.locations }}">
+                          </indicator-locations-widget>
+                        </div>
+                      </template>
+                      
+                    </div>
+                  </template>
+                </div>
+              </template>
+              
+              <template
+                is="dom-if"
+                if="[[_equals(modalTitle, 'Add Activity Indicator')]]"
+                restamp="true">
+              
+                <paper-radio-button name="activity">
+                  <strong>Adopt from Cluster Activity</strong>
+                </paper-radio-button>
+
+                <div
+                  class="fields"
+                  empty$="[[!_equals(mode, 'activity')]]">
+                  <template
+                    is="dom-if"
+                    if="[[_equals(mode, 'activity')]]"
+                    restamp="true">
+                    
+                    <div class="app-grid">
+                      <div class="item">
+                        <etools-single-selection-menu
+                          id="clustersDropdown"
+                          class="validate"
+                          label="Clusters *"
+                          options="[[clusters]]"
+                          option-value="id"
+                          option-label="title"
+                          selected="{{ selectedCluster }}"
                           on-iron-activate="_validate"
                           required>
                         </etools-single-selection-menu>
-                      </template>
-                    </div>
-
-                    <div class="item">
-                      <etools-single-selection-menu
-                        id="clustersDropdown"
-                        class="validate"
-                        label="Clusters *"
-                        options="[[clusters]]"
-                        option-value="id"
-                        option-label="title"
-                        selected="{{ selectedCluster }}"
-                        on-iron-activate="_validate"
-                        disabled="[[_equals(selectedPartner, '')]]"
-                        required>
-                      </etools-single-selection-menu>
-                    </div>
-  
-                    <div class="item">
-                      <etools-single-selection-menu
+                      </div>
+    
+                      <div class="item">
+                        <etools-single-selection-menu
+                            class="validate"
+                            label="Activity *"
+                            options="[[activities]]"
+                            option-value="id"
+                            option-label="title"
+                            selected="{{ selectedActivity }}"
+                            on-iron-select="_validate"
+                            disabled="[[_equals(activities.length, 0)]]"
+                            required>
+                        </etools-single-selection-menu>
+                      </div>
+    
+                      <div class="item full-width">
+                        <etools-single-selection-menu
                           class="validate"
-                          label="Objective *"
-                          options="[[objectives]]"
+                          label="Indicator *"
+                          options="[[indicators]]"
                           option-value="id"
                           option-label="title"
-                          selected="{{ selectedObjective }}"
+                          selected="{{ selectedIndicator }}"
                           on-iron-select="_validate"
-                          disabled="[[_equals(objectives.length, 0)]]"
+                          disabled="[[_equals(indicators.length, 0)]]"
                           required>
-                      </etools-single-selection-menu>
-                    </div>
-  
-                    <div class="item full-width">
-                      <etools-single-selection-menu
-                        class="validate"
-                        label="Indicator *"
-                        options="[[indicators]]"
-                        option-value="id"
-                        option-label="title"
-                        selected="{{ selectedIndicator }}"
-                        on-iron-select="_validate"
-                        disabled="[[_equals(indicators.length, 0)]]"
-                        required>
-                      </etools-single-selection-menu>
-                    </div>
-  
-                    <json-field
-                      class="item validate"
-                      id="target"
-                      label="Baseline"
-                      value="{{ data.baseline }}"
-                      type="[[selectedIndicatorDetailType]]"
-                      allowed-pattern="[+\-\d.]"
-                      on-input="_validate">
-                    </json-field>
-  
-                    <json-field
-                      class="item validate"
-                      id="total"
-                      label="Target"
-                      value="{{ data.target }}"
-                      type="[[selectedIndicatorDetailType]]"
-                      allowed-pattern="[+\-\d.]"
-                      on-input="_validate">
-                    </json-field>
-  
-                    <template
-                      is="dom-if"
-                      if="[[selectedIndicatorDetailType]]"
-                      restamp="true">
-                      <div class="item full-width">
-                        <indicator-locations-widget
-                          class="validate"
-                          indicator-type="[[selectedIndicatorDetailType]]"
-                          value="{{ data.locations }}">
-                        </indicator-locations-widget>
+                        </etools-single-selection-menu>
                       </div>
-                    </template>
-                    
-                  </div>
-                </template>
-              </div>
+    
+                      <json-field
+                        class="item validate"
+                        id="target"
+                        label="Baseline"
+                        value="{{ data.baseline }}"
+                        type="[[selectedIndicatorDetailType]]"
+                        allowed-pattern="[+\-\d.]"
+                        on-input="_validate">
+                      </json-field>
+    
+                      <json-field
+                        class="item validate"
+                        id="total"
+                        label="Target"
+                        value="{{ data.target }}"
+                        type="[[selectedIndicatorDetailType]]"
+                        allowed-pattern="[+\-\d.]"
+                        on-input="_validate">
+                      </json-field>
+    
+                      <template
+                        is="dom-if"
+                        if="[[selectedIndicatorDetailType]]"
+                        restamp="true">
+                        <div class="item full-width">
+                          <indicator-locations-widget
+                            class="validate"
+                            indicator-type="[[selectedIndicatorDetailType]]"
+                            value="{{ data.locations }}">
+                          </indicator-locations-widget>
+                        </div>
+                      </template>
+                      
+                    </div>
+                  </template>
+                </div>
+              </template>
   
               <paper-radio-button name="custom">
                 <strong>Custom</strong>
@@ -806,13 +904,9 @@
       properties: {
         data: Object,
         objectId: Number,
+        activityData: Object,
         objectType: String,
         modalTitle: String,
-
-        imoInPartner: {
-          type: Boolean,
-          value: false,
-        },
 
         isNumber: {
           type: Boolean,
@@ -894,26 +988,6 @@
           computed: '_computeObjectivesUrl(responsePlanId)',
         },
 
-        partnersUrl: {
-          type: String,
-          computed: '_computePartnersUrl(responsePlanId)',
-        },
-
-        partner: {
-          type: Object,
-          statePath: 'partner.current',
-        },
-
-        partners: {
-          type: Array,
-          value: [],
-        },
-
-        selectedPartner: {
-          type: String,
-          value: '',
-        },
-
         partnerID: {
           type: String,
           statePath: 'partner.current.id',
@@ -991,8 +1065,6 @@
         '_resetCalculationFormulas(isNumber)',
         '_resetFields(isNumber)',
         '_updateCSDates(data.start_date_of_reporting_period)',
-        '_fetchPartnersList(partner)',
-        '_savePartner(selectedPartner)',
         '_saveCluster(selectedCluster)',
         '_fetchObjectivesList(selectedCluster)',
         '_fetchIndicatorsList(selectedObjective)',
@@ -1072,7 +1144,7 @@
 
         if (this.mode === 'objectives') {
           this.set('data', {
-            partner_id: '',
+            partner_id: this.projectData.partner_id || this.activityData.partner.id || this.partnerID,
             partner_project_id: '',
             cluster_id: '',
             cluster_objective_id: '',
@@ -1083,10 +1155,6 @@
           });
 
           this.set('indicatorsUrl', App.Endpoints.adoptedClusterIndicators());
-
-          if (this.imoInPartner === false) {
-            this.set('selectedPartner', this.partnerID);
-          }
         } else {
           this.set('selectedDisaggregations', []);
           this.set('errors', {});
@@ -1127,10 +1195,6 @@
         return App.Endpoints.responseParametersClusterObjectives(responsePlanId);
       },
 
-      _computePartnersUrl: function (responsePlanId) {
-        return App.Endpoints.clusterPartnerNames(responsePlanId);
-      },
-
       _fetchDisaggregations: function() {
         var self = this;
 
@@ -1138,24 +1202,6 @@
           .then(function(res) {
             self.set('disaggregations', res.data.results);
           });
-      },
-
-      _fetchPartnersList: function () {
-        this.debounce('fetch-objectives', function () {
-          var self = this;
-
-          this.set('partners', []);
-
-          this.$.partners.abort();
-          this.$.partners.thunk()()
-            .then(function (res) {
-              self.set('partners', res.data);
-              self.fire('details-loaded');
-            })
-            .catch(function (err) { // jshint ignore:line
-              // TODO: error handling
-            });
-        }, 100);
       },
 
       _savePartner: function (selectedPartnerId) {
@@ -1395,9 +1441,6 @@
             e.target.nodeName === 'PAPER-ICON-BUTTON') {
           this.set('mode', '');
           this.set('data', {});
-
-          this.set('partners', []);
-          this.set('selectedPartner', '');
 
           this.set('clusters', []);
           this.set('selectedCluster', '');

--- a/polymer/src/elements/cluster-reporting/indicator-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-modal.html
@@ -1248,7 +1248,6 @@
           return;
         }
         this.set('activities', []);
-        this.set('data.cluster.cluster_activity', undefined);
         this.set('activitiesParams.cluster_id', clusterId);
         this.set('activitiesUrl',
             App.Endpoints.responseParametersClusterActivities(this.responsePlanId)
@@ -1282,8 +1281,7 @@
               var simpleIndicatorsList = [];
 
               res.data.results.forEach(function (indicator) {
-                var simpleIndicator = {};
-                simpleIndicator.id = indicator.id;
+                var simpleIndicator = indicator;
                 simpleIndicator.title = indicator.blueprint.title;
 
                 simpleIndicatorsList.push(simpleIndicator);
@@ -1299,8 +1297,11 @@
         if (selectedClusterId === '') {
           return;
         }
-        this.set('data.cluster_id', selectedClusterId);
-        this.set('data.partner_project_id', parseInt(this.objectId));
+        
+        if (this.mode === 'objectives') {
+          this.set('data.cluster_id', selectedClusterId);
+          this.set('data.partner_project_id', parseInt(this.objectId));
+        }
 
         this.debounce('fetch-objectives', function () {
           var self = this;
@@ -1366,12 +1367,26 @@
             this.set('data.reportable_id', selectedIndicator);
           }
 
+          if (this.mode === 'activity') {
+            var chosenActivityIndicator = this.indicators.find(function (indicator) {
+              return indicator.id === selectedIndicator;
+            });
+
+            console.log('indicator', chosenActivityIndicator);
+
+            this.set('data.blueprint.title', chosenActivityIndicator.title);
+            this.set('data.frequency', chosenActivityIndicator.frequency);
+            this.set('data.label', chosenActivityIndicator.label);
+            this.set('data.start_date_of_reporting_period', chosenActivityIndicator.start_date_of_reporting_period);
+          }
+
           this.$.indicatorDetail.url = App.Endpoints.analysisIndicator(responsePlanId, selectedIndicator);
 
           this.$.indicatorDetail.abort();
           this.$.indicatorDetail.thunk()()
             .then(function (res) {
               self.set('selectedIndicatorDetailType', res.data.display_type);
+              console.log('data right now', self.data);
             })
             .catch(function (err) { // jshint ignore:line
               // TODO: error handling

--- a/polymer/src/elements/cluster-reporting/indicator-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-modal.html
@@ -125,7 +125,7 @@
       id="activities"
       params="[[activitiesParams]]"
       url="[[activitiesUrl]]">
-  </etools-prp-ajax>
+    </etools-prp-ajax>
 
     <etools-prp-ajax
       id="indicators"
@@ -205,25 +205,6 @@
                     restamp="true">
                     
                     <div class="app-grid">
-                      <div class="item full-width">
-                        <template
-                          is="dom-if"
-                          if="[[imoInPartner]]"
-                          restamp="true">
-  
-                          <etools-single-selection-menu
-                            class="validate"
-                            label="Partners *"
-                            options="[[partners]]"
-                            option-value="id"
-                            option-label="title"
-                            selected="{{ selectedPartner }}"
-                            on-iron-activate="_validate"
-                            required>
-                          </etools-single-selection-menu>
-                        </template>
-                      </div>
-  
                       <div class="item">
                         <etools-single-selection-menu
                           id="clustersDropdown"

--- a/polymer/src/elements/cluster-reporting/indicator-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-modal.html
@@ -344,7 +344,7 @@
                             options="[[activities]]"
                             option-value="id"
                             option-label="title"
-                            selected="{{ data.cluster_activity_id }}"
+                            selected="{{ selectedActivity }}"
                             on-iron-select="_validate"
                             disabled="[[_equals(activities.length, 0)]]"
                             required>
@@ -963,6 +963,11 @@
           value: [],
         },
 
+        selectedActivity: {
+          type: String,
+          value: '',
+        },
+
         clusters: {
           format: Array,
           value: [],
@@ -998,10 +1003,7 @@
           value: '',
         },
 
-        selectedIndicatorDetailType: {
-          type: String,
-          value: ''
-        },
+        selectedIndicatorDetailType: String,
 
         objectivesUrl: {
           type: String,
@@ -1089,7 +1091,7 @@
         '_fetchActivities(selectedCluster)',
         '_fetchObjectivesList(selectedCluster)',
         '_fetchIndicatorsList(selectedObjective)',
-        '_fetchActivityIndicatorsList(data.cluster_activity_id)',
+        '_fetchActivityIndicatorsList(selectedActivity)',
         '_fetchSelectedIndicatorDetailType(responsePlanId, selectedIndicator)',
       ],
 
@@ -1166,7 +1168,7 @@
 
         if (this.mode === 'objectives') {
           this.set('data', {
-            partner_id: this.projectData.partner_id || this.activityData.partner.id || this.partnerID,
+            partner_id: this.projectData.partner_id || this.partnerID,
             partner_project_id: '',
             cluster_id: '',
             cluster_objective_id: '',
@@ -1177,19 +1179,6 @@
           });
 
           this.set('indicatorsUrl', App.Endpoints.adoptedClusterIndicators());
-        } else if (this.mode === 'activity') {
-          this.set('data', {
-            partner_id: this.activityData.partner.id || this.partnerID,
-            partner_project_id: '',
-            cluster_id: '',
-            cluster_activity_id: '',
-            reportable_id: '',
-            locations: [],
-            target: {d: 1},
-            baseline: {d: 1}
-          });
-
-          this.set('indicatorsListUrl', App.Endpoints.indicators('ca') + '/');
         } else {
           this.set('selectedDisaggregations', []);
           this.set('errors', {});
@@ -1203,6 +1192,10 @@
             locations: [],
             disaggregations: [],
           });
+
+          if (this.mode === 'activity') {
+            this.set('indicatorsListUrl', App.Endpoints.indicators('ca') + '/');
+          };
 
           this.set('indicatorsUrl', App.Endpoints.clusterIndicators());
 
@@ -1244,7 +1237,9 @@
       },
 
       _saveCluster: function () {
-        this.set('data.cluster_id', this.selectedCluster);
+        if (this.mode === 'objectives') {
+          this.set('data.cluster_id', this.selectedCluster);
+        }
       },
 
       _fetchActivities: function (clusterId) {
@@ -1284,7 +1279,6 @@
           this.$.indicatorsList.abort();
           this.$.indicatorsList.thunk()()
             .then(function (res) {
-              console.log('res', res);
               var simpleIndicatorsList = [];
 
               res.data.results.forEach(function (indicator) {
@@ -1361,15 +1355,16 @@
       },
 
       _fetchSelectedIndicatorDetailType: function (responsePlanId, selectedIndicator) {
-        if (selectedIndicator === undefined) {
+        if (selectedIndicator === undefined || selectedIndicator === '') {
           return;
         }
 
         this.debounce('fetch-selected-indicator', function () {
           var self = this;
 
-          this.set('selectedIndicatorDetailType', '');
-          this.set('data.reportable_id', selectedIndicator);
+          if (this.mode === 'objectives') {
+            this.set('data.reportable_id', selectedIndicator);
+          }
 
           this.$.indicatorDetail.url = App.Endpoints.analysisIndicator(responsePlanId, selectedIndicator);
 
@@ -1537,9 +1532,12 @@
           this.set('objectives', []);
           this.set('selectedObjective', '');
 
+          this.set('activities', []);
+          this.set('selectedActivity', '');
+
           this.set('indicators', []);
           this.set('selectedIndicator', '');
-          this.set('selectedIndicatorDetailType', '');
+          this.set('selectedIndicatorDetailType', undefined);
           
           this.close();
         } else {

--- a/polymer/src/elements/cluster-reporting/response-parameters/partners/activities/indicators.html
+++ b/polymer/src/elements/cluster-reporting/response-parameters/partners/activities/indicators.html
@@ -59,6 +59,7 @@
       <indicator-modal
           id="indicatorModal"
           object-id="[[activityId]]"
+          activity-data="[[activityData]]"
           object-type="partner.partneractivity"
           modal-title="Add Activity Indicator">
       </indicator-modal>

--- a/polymer/src/elements/cluster-reporting/response-parameters/partners/projects/indicators.html
+++ b/polymer/src/elements/cluster-reporting/response-parameters/partners/projects/indicators.html
@@ -153,7 +153,6 @@
       },
 
       _openModal: function () {
-        console.log('project data', this.projectData);
         this.$.indicatorModal.open();
       },
 


### PR DESCRIPTION
### This PR completes ch12052 (and ch12047).

##### Feature list
* _Describe the list of features from Polymer_
  * Added conditionally-rendered radio option for Adopt from Cluster Activity
  * Added methods and observers for getting partner activities and cluster activity indicators
  * Correctly build data object for adopted partner activity indicator and verify POST works for both custom and adopted partner activity indicators

##### Progress checker
- [ ] Polymer

- [ ] Polymer test cases
