### PR TITLE
[ch12142] Fix submit button for report that was sent back

### DIFF
--- a/polymer/src/elements/reportable-meta.html
+++ b/polymer/src/elements/reportable-meta.html
@@ -285,8 +285,10 @@
       },
 
       detached: function () {
-        this.set(['localData', 'narrative_assessment'],
-          Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input').value);
+        if (Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input') !== null) {
+          this.set(['localData', 'narrative_assessment'],
+            Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input').value);
+        }
         
         if (this.isDebouncerActive('local-data-changed')) {
           this.cancelDebouncer('local-data-changed');

--- a/polymer/src/pages/app/ip-reporting/pd/pd-report.html
+++ b/polymer/src/pages/app/ip-reporting/pd/pd-report.html
@@ -367,6 +367,9 @@
       },
 
       _onReportStatusChanged: function (currentReport, mode) {
+        if (currentReport.status === 'Sen') {
+          this.set('routeData.mode', 'edit');
+        }
         if (
           this._isReadOnlyReport(currentReport) &&
           (mode || '').toLowerCase !== 'view'


### PR DESCRIPTION
### This PR completes ch12142.

##### Feature list
* _Describe the list of features from Polymer_
  * Added conditional to manually set mode to "edit" if report was sent back to properly render Submit button
  * Added a conditional to resolve an error that would occur when navigating away from a report. The report would try to auto-save its narrative assessment even if no changes had been made to the narrative assessment - the conditional should prevent it from autosaving when no changes have been made.

##### Progress checker
- [ ] Polymer

- [ ] Polymer test cases
