### PR TITLE
Show only one delete button for user in ID Management

### DIFF
--- a/react/id_management_frontend/src/components/Users/UserRowExpanded.jsx
+++ b/react/id_management_frontend/src/components/Users/UserRowExpanded.jsx
@@ -55,7 +55,8 @@ class UserRowExpanded extends Component {
                 {permissions.editUserPermission(role, row) &&
                 <Fragment>
                     <LinkButton label={labels.edit} onClick={() => onPermissionEdit(row, role)}/>
-                    <LinkButton label={labels.delete} variant="danger" onClick={() => onPermissionDelete(role)}/>
+                    {!permissions.revokeIpAdmin(role) &&
+                    <LinkButton label={labels.delete} variant="danger" onClick={() => onPermissionDelete(role)}/>}
                 </Fragment>}
 
                 {permissions.makeIpAdmin(role) &&


### PR DESCRIPTION
### This PR is not tied to a single ticket - related to ch12127.

##### Feature list
* _Describe the list of features from Polymer_
  * When a user gets created in ID Management, there would be three options shown if the user has a role in the workspace: `edit`, `delete`, and `(make IP Admin)`. If they are made an IP Admin, that third option gets replaced with another `delete`, so there end up being two `delete` buttons. They both do the same thing (delete the user), so this fix should make it so that the first `delete` option is shown only if the user is not an IP Admin. If the user is an IP Admin, the first delete is hidden, and the second delete button is shown.

##### Progress checker
- [ ] Polymer

- [ ] Polymer test cases
