### PR TITLE
Fix theme color in reports

### DIFF
--- a/polymer/src/elements/indicator-details.html
+++ b/polymer/src/elements/indicator-details.html
@@ -46,7 +46,7 @@
         };
 
         --paper-item-selected: {
-          background-color: #44b4ff;
+          background-color: var(--theme-secondary-color-d);
         };
 
         --paper-tabs: {

--- a/polymer/src/elements/reportable-meta.html
+++ b/polymer/src/elements/reportable-meta.html
@@ -47,8 +47,6 @@
       }
 
       #toggle-button {
-        background-color: #0099ff;
-        color: #fff;
         font-size: 14px;
       }
 

--- a/polymer/src/styles/app-theme-cluster.html
+++ b/polymer/src/styles/app-theme-cluster.html
@@ -9,6 +9,7 @@
         --theme-secondary-color-a: #ceffcc;
         --theme-secondary-color-b: #88c245;
         --theme-secondary-color-c: #233944;
+        --theme-secondary-color-d: #009d55;
 
         --theme-primary-text-color-dark: #212121;
         --theme-primary-text-color-medium: #c0c0c0;

--- a/polymer/src/styles/app-theme-cluster.html
+++ b/polymer/src/styles/app-theme-cluster.html
@@ -9,7 +9,7 @@
         --theme-secondary-color-a: #ceffcc;
         --theme-secondary-color-b: #88c245;
         --theme-secondary-color-c: #233944;
-        --theme-secondary-color-d: #009d55;
+        --theme-secondary-color-d: #0bad62;
 
         --theme-primary-text-color-dark: #212121;
         --theme-primary-text-color-medium: #c0c0c0;

--- a/polymer/src/styles/app-theme-ip.html
+++ b/polymer/src/styles/app-theme-ip.html
@@ -9,6 +9,7 @@
         --theme-secondary-color-a: #ccebff;
         --theme-secondary-color-b: #2baaff;
         --theme-secondary-color-c: #233944;
+        --theme-secondary-color-d: #3db2ff;
 
         --theme-primary-text-color-dark: #212121;
         --theme-primary-text-color-medium: #c0c0c0;


### PR DESCRIPTION
The theme colors for the `Narrative assessment` Save button and the location list items had been hardcoded to follow the IP Reporting color scheme. This meant that when those components were being used in Cluster Reporting, they looked very out of place. This PR should fix that so the components actually use the correct color schemes depending on what app they're being used in.

##### Feature list
* _Describe the list of features from Polymer_
  * Added a new CSS variable for the paper-item color in the location list
  * Deleted the hardcoded color values for the Edit/Save button for the narrative assessment so that it can use the appropriate color dynamically

##### Progress checker
- [ ] Polymer

- [ ] Polymer test cases
