### PR TITLE
[ch12702] Fix issue with attachments' file extensions

### DIFF
--- a/polymer/src/elements/ip-reporting/report-attachments.html
+++ b/polymer/src/elements/ip-reporting/report-attachments.html
@@ -325,13 +325,11 @@
 
               if (attachment.id === null) {
                 var duplicates = attachments.filter(function(item) {
-                  var tokens = attachment.file_name.split('.');
-                  if (tokens.length === 0) {
-                    return item.file_name.indexOf(attachment.file_name) !== -1;
-                  } else {
-                    return item.file_name.indexOf(tokens[0]) !== -1;
-                  }
+                  console.log('item', item);
+                  return item.file_name.indexOf(attachment.file_name) !== -1;
                 });
+
+                console.log('duplicates', duplicates);
 
                 if (duplicates.length === 1) {
                   self.set(attachmentPropertyName, [duplicates[0]]);

--- a/polymer/src/elements/ip-reporting/report-attachments.html
+++ b/polymer/src/elements/ip-reporting/report-attachments.html
@@ -325,7 +325,6 @@
 
               if (attachment.id === null) {
                 var duplicates = attachments.filter(function(item) {
-                  console.log('item', item);
                   var tokens = attachment.file_name.split('.');
                   if (tokens.length === 0) {
                     return item.file_name.indexOf(attachment.file_name) !== -1;
@@ -333,8 +332,6 @@
                     return item.file_name.indexOf(tokens[0]) !== -1 && item.file_name.indexOf(tokens[1]) !== -1;
                   }
                 });
-
-                console.log('duplicates', duplicates);
 
                 if (duplicates.length === 1) {
                   self.set(attachmentPropertyName, [duplicates[0]]);

--- a/polymer/src/elements/ip-reporting/report-attachments.html
+++ b/polymer/src/elements/ip-reporting/report-attachments.html
@@ -326,7 +326,12 @@
               if (attachment.id === null) {
                 var duplicates = attachments.filter(function(item) {
                   console.log('item', item);
-                  return item.file_name.indexOf(attachment.file_name) !== -1;
+                  var tokens = attachment.file_name.split('.');
+                  if (tokens.length === 0) {
+                    return item.file_name.indexOf(attachment.file_name) !== -1;
+                  } else {
+                    return item.file_name.indexOf(tokens[0]) !== -1 && item.file_name.indexOf(tokens[1]) !== -1;
+                  }
                 });
 
                 console.log('duplicates', duplicates);


### PR DESCRIPTION
### This PR completes ch12702.

There was a visual bug occurring when a user would upload multiple files with the same file name, but not the same extension. The UI on the attachments would get swapped somehow, showing the just-uploaded attachment with the exact same file extension as the existing one, even though upon refresh, it would display correctly. This PR should fix this.

##### Feature list
* _Describe the list of features from Polymer_
  * Tweaked existing conditional to also check the file extension along with the file name for duplicates

##### Progress checker
- [ ] Polymer

- [ ] Polymer test cases
