### PR TITLE
[ch12897] Prevent autosave for narrative assessment from running for all fields

### DIFF
--- a/polymer/src/elements/reportable-meta.html
+++ b/polymer/src/elements/reportable-meta.html
@@ -283,7 +283,10 @@
       },
 
       detached: function () {
-        if (Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input') !== null) {
+        if (Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input') !== null
+          && Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-button').textContent.trim() === 'Save'
+        ) {
+          console.log('node', Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-button').textContent.trim());
           this.set(['localData', 'narrative_assessment'],
             Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input').value);
         }

--- a/polymer/src/elements/reportable-meta.html
+++ b/polymer/src/elements/reportable-meta.html
@@ -286,7 +286,6 @@
         if (Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input') !== null
           && Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-button').textContent.trim() === 'Save'
         ) {
-          console.log('node', Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-button').textContent.trim());
           this.set(['localData', 'narrative_assessment'],
             Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input').value);
         }

--- a/polymer/src/elements/reportable-meta.html
+++ b/polymer/src/elements/reportable-meta.html
@@ -284,7 +284,9 @@
 
       detached: function () {
         if (Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input') !== null
-          && Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-button').textContent.trim() === 'Save'
+          && Polymer.dom(this.root)
+            .querySelectorAll('labelled-item')[1]
+            .querySelector('paper-button').textContent.trim() === 'Save'
         ) {
           this.set(['localData', 'narrative_assessment'],
             Polymer.dom(this.root).querySelectorAll('labelled-item')[1].querySelector('paper-input').value);


### PR DESCRIPTION
### This PR completes ch12897.

##### Feature list
* _Describe the list of features from Polymer_
  * Added another conditional to check and see if user has actually clicked Edit on a narrative assessment field before saving it. This should prevent the `detached` method from checking all narrative fields and making PATCH API calls for each one, and now only make a PATCH for a narrative assessment whose corresponding Edit/Save button reads Save.

##### Progress checker
- [ ] Polymer

- [ ] Polymer test cases
