### PR TITLE
Check if nullData is defined before setting values to null

### DIFF
--- a/polymer/src/elements/disaggregations/disaggregation-table-cell-number.html
+++ b/polymer/src/elements/disaggregations/disaggregation-table-cell-number.html
@@ -44,10 +44,10 @@
 
       attached: function () {
         var nullData = this._clone(this.data);
-        if (nullData.v === 0) {
+        if (nullData !== undefined && nullData.v === 0) {
           nullData.v = null;
         }
-        if (nullData.d === 0) {
+        if (nullData !== undefined && nullData.d === 0) {
           nullData.d = null;
         }
         this.set('data', nullData);

--- a/polymer/src/elements/disaggregations/disaggregation-table-cell-percentage.html
+++ b/polymer/src/elements/disaggregations/disaggregation-table-cell-percentage.html
@@ -182,10 +182,10 @@
 
       attached: function () {
         var nullData = this._clone(this.data);
-        if (nullData.v === 0) {
+        if (nullData !== undefined && nullData.v === 0) {
           nullData.v = null;
         }
-        if (nullData.d === 0) {
+        if (nullData !== undefined && nullData.d === 0) {
           nullData.d = null;
         }
         this.set('data', nullData);

--- a/polymer/src/elements/disaggregations/disaggregation-table-cell-ratio.html
+++ b/polymer/src/elements/disaggregations/disaggregation-table-cell-ratio.html
@@ -200,10 +200,10 @@
 
       attached: function () {
         var nullData = this._clone(this.data);
-        if (nullData.v === 0) {
+        if (nullData !== undefined && nullData.v === 0) {
           nullData.v = null;
         }
-        if (nullData.d === 0) {
+        if (nullData !== undefined && nullData.d === 0) {
           nullData.d = null;
         }
         this.set('data', nullData);


### PR DESCRIPTION
Small bug I came across - a console error would pop up whenever opening an indicator report without any data values for a location.

##### Feature list
* _Describe the list of features from Polymer_
  * Added an extra conditional checking to make sure data is not undefined

##### Progress checker
- [x] Polymer

- [x] Polymer test cases
