### PR TITLE
[ch12716] Fix issue where report data in indicator detail slot is not rendering

### DIFF
--- a/polymer/src/elements/ip-reporting/ip-reporting-indicator-details.html
+++ b/polymer/src/elements/ip-reporting/ip-reporting-indicator-details.html
@@ -279,7 +279,9 @@
       },
 
       _getDataByKey: function(dataDict) {
-        IndicatorDetailsUtils.getDataByKey(dataDict, this.indicator);
+        if (dataDict.details) {
+          this.data = dataDict.details[this.indicator.id];
+        }
       },
 
       _computeHidden: function (data, loading) {

--- a/polymer/src/elements/ip-reporting/js/ip-reporting-indicator-details.js
+++ b/polymer/src/elements/ip-reporting/js/ip-reporting-indicator-details.js
@@ -2,12 +2,6 @@ function IndicatorDetailsUtils() {
         
 }
 
-IndicatorDetailsUtils.getDataByKey = function (dataDict, indicator) {
-    if (dataDict.details) {
-        this.data = dataDict.details[indicator.id];
-    }
-};
-
 IndicatorDetailsUtils.computeIsClusterApp = function (name) {
     return name === 'cluster-reporting';
 };

--- a/polymer/test/unit/ip-reporting-indicator-details.test.js
+++ b/polymer/test/unit/ip-reporting-indicator-details.test.js
@@ -7,31 +7,6 @@ const {getDataByKey,
     bucketByLocation} = IndicatorDetailsUtils;
 
 describe('IpReportingIndicatorDetails functions', () => {
-    describe('getDataByKey observer', () => {
-        // found in polymer/src/elements/ip-reporting/ip-reporting-indicator-details.js
-        const dataObj = {
-            details: {
-                1: 'hello'
-            }
-        };
-    
-        const ind = {id: 1};
-        const badObj = {deets: 'howdy'};
-        const nullObj = '';
-    
-        xit('should equal hello', () => {
-            expect(getDataByKey(dataObj, ind)).toBe('hello');
-        });
-    
-        it('should return undefined if dataDict has no details', () => {
-            expect(getDataByKey(badObj, ind)).toBe(undefined);
-        });
-    
-        it('should return undefined if dataDict is not an object', () => {
-            expect(getDataByKey(nullObj, ind)).toBe(undefined);
-        });
-    });
-    
     describe('clusterApp function', () => {
         // found in polymer/src/elements/ip-reporting/ip-reporting-indicator-details.js
         const appName = 'cluster-reporting';


### PR DESCRIPTION
### This PR completes ch12716.

##### Feature list
* _Describe the list of features from Polymer_
  * Moved externalized logic back into component to preserve `this` keyword context and have the data actually get set correctly. This function was one of the ones that couldn't live outside the component, but for some reason I moved it outside to a separate file anyway. Now that it's back in the component, the data should render correctly.
  * Removed unnecessary unit tests now that function logic is no longer outside the component

##### Progress checker
- [x] Polymer

- [x] Polymer test cases
