### PR TITLE
[ch12109] Allow IP Admin to submit reports

### DIFF
--- a/django_api/django_api/apps/indicator/views.py
+++ b/django_api/django_api/apps/indicator/views.py
@@ -472,7 +472,11 @@ class PDLowerLevelOutputStatusAPIView(APIView):
         super().check_permissions(request)
         pd_progress_report_id = self.kwargs.get('pd_progress_report_id')
         if not request.user.prp_roles.filter(
-                role__in=[PRP_ROLE_TYPES.ip_authorized_officer, PRP_ROLE_TYPES.ip_editor],
+                role__in=[
+                    PRP_ROLE_TYPES.ip_authorized_officer,
+                    PRP_ROLE_TYPES.ip_editor,
+                    PRP_ROLE_TYPES.ip_admin,
+                ],
                 workspace__partner_focal_programme_documents__progress_reports__id=pd_progress_report_id
         ).exists():
             self.permission_denied(request)

--- a/django_api/django_api/apps/unicef/views.py
+++ b/django_api/django_api/apps/unicef/views.py
@@ -364,6 +364,7 @@ class ProgressReportDetailsUpdateAPIView(APIView):
         AnyPermission(
             IsPartnerAuthorizedOfficerForCurrentWorkspace,
             IsPartnerEditorForCurrentWorkspace,
+            IsPartnerAdminForCurrentWorkspace,
         ),
     )
 

--- a/django_api/django_api/apps/unicef/views.py
+++ b/django_api/django_api/apps/unicef/views.py
@@ -1111,6 +1111,7 @@ class ProgressReportAttachmentListCreateAPIView(ListCreateAPIView):
             IsUNICEFAPIUser,
             IsPartnerAuthorizedOfficerForCurrentWorkspace,
             IsPartnerEditorForCurrentWorkspace,
+            IsPartnerAdminForCurrentWorkspace,
         ),
     )
     parser_classes = (FormParser, MultiPartParser, FileUploadParser)
@@ -1142,6 +1143,7 @@ class ProgressReportAttachmentAPIView(APIView):
             IsUNICEFAPIUser,
             IsPartnerAuthorizedOfficerForCurrentWorkspace,
             IsPartnerEditorForCurrentWorkspace,
+            IsPartnerAdminForCurrentWorkspace,
         ),
     )
 

--- a/django_api/django_api/apps/unicef/views.py
+++ b/django_api/django_api/apps/unicef/views.py
@@ -516,12 +516,13 @@ class ProgressReportLocationsAPIView(ListAPIView):
 
 class ProgressReportSubmitAPIView(APIView):
     """
-    Only a partner authorized officer and partner editor can submit a progress report.
+    Only a partner authorized officer, partner admin, and partner editor can submit a progress report.
     """
     permission_classes = (
         AnyPermission(
             IsPartnerAuthorizedOfficerForCurrentWorkspace,
             IsPartnerEditorForCurrentWorkspace,
+            IsPartnerAdminForCurrentWorkspace,
         ),
     )
 
@@ -650,12 +651,13 @@ class ProgressReportSubmitAPIView(APIView):
 class ProgressReportSRSubmitAPIView(APIView):
     """
     A dedicated API endpoint for submitting SR Progress Report.
-    Only a partner authorized officer and partner editor can submit a progress report.
+    Only a partner authorized officer, partner admin, and partner editor can submit a progress report.
     """
     permission_classes = (
         AnyPermission(
             IsPartnerAuthorizedOfficerForCurrentWorkspace,
             IsPartnerEditorForCurrentWorkspace,
+            IsPartnerAdminForCurrentWorkspace,
         ),
     )
 

--- a/polymer/src/elements/etools-prp-permissions.html
+++ b/polymer/src/elements/etools-prp-permissions.html
@@ -29,6 +29,7 @@
           editProgressReport: [
             App.Constants.PRP_ROLE.IP_AUTHORIZED_OFFICER,
             App.Constants.PRP_ROLE.IP_EDITOR,
+            App.Constants.PRP_ROLE.IP_ADMIN,
           ],
 
           exportSubmittedProgressReport: [
@@ -39,6 +40,7 @@
           savePdReport: [
             App.Constants.PRP_ROLE.IP_AUTHORIZED_OFFICER,
             App.Constants.PRP_ROLE.IP_EDITOR,
+            App.Constants.PRP_ROLE.IP_ADMIN,
           ],
 
           changeProgrammeDocumentCalculationMethod: [

--- a/polymer/src/elements/reportable-meta.html
+++ b/polymer/src/elements/reportable-meta.html
@@ -111,7 +111,7 @@
       </template>
     </labelled-item>
 
-    <labelled-item label="[[localize('narrative_assessment')]]">
+    <labelled-item id="labelled-narrative" label="[[localize('narrative_assessment')]]">
       <template
           is="dom-if"
           if="[[!_equals(mode, 'view')]]"
@@ -214,7 +214,7 @@
         var field = Polymer.dom(event).rootTarget;
         var narrativeTextInput = this.$$('#narrative_assessment');
 
-        if (field.textContent.trim() === 'Edit') {
+        if (this.toggle === 'Edit') {
           narrativeTextInput.disabled = false;
           narrativeTextInput.focus();
           this.set('toggle', 'Save');
@@ -223,7 +223,7 @@
 
         if (field.id === 'toggle-button') {
           var parent = Polymer.dom(event).path.find(function(node) {
-            return node.label === 'Narrative assessment';
+            return node.id === 'labelled-narrative';
           });
 
           field = parent.querySelector('paper-input');
@@ -238,7 +238,9 @@
             break;
 
           case 'narrative_assessment':
-            if (this.data.narrative_assessment === field.value.trim()) {
+            if (field.value !== null && this.data.narrative_assessment === field.value.trim()
+              || field.value === null && this.data.narrative_assessment === null
+            ) {
               this.set('toggle', 'Edit');
               narrativeTextInput.disabled = true;
               break;

--- a/polymer/src/elements/reportable-meta.html
+++ b/polymer/src/elements/reportable-meta.html
@@ -214,7 +214,7 @@
         var field = Polymer.dom(event).rootTarget;
         var narrativeTextInput = this.$$('#narrative_assessment');
 
-        if (this.toggle === 'Edit') {
+        if (this.toggle === 'Edit' && field.id === 'toggle-button') {
           narrativeTextInput.disabled = false;
           narrativeTextInput.focus();
           this.set('toggle', 'Save');
@@ -233,8 +233,6 @@
         switch (id) {
           case 'overall_status':
             this.set(['localData', id], field.selected);
-            this.set('toggle', 'Edit');
-            narrativeTextInput.disabled = true;
             break;
 
           case 'narrative_assessment':


### PR DESCRIPTION
### This PR completes ch12109.

##### Feature list
* _Describe the list of features from Django_
  * Update several API views related to submitting Progress Reports to allow for user with IP Admin role to submit them

* _Describe the list of features from Polymer_
  * Update `etools-prp-permissions` component to allow IP Admin role to submit progress reports
  * Fix bugs related to localization conflicting with Progress Report overall status and narrative assessment save functionality

##### Progress checker
- [x] Django

- [x] Polymer

- [x] Django test cases

- [x] Polymer test cases
