### PR TITLE
Add IP Admin permissions to IndicatorLocationDataUpdateAPIView [ch12109]

### DIFF
--- a/django_api/django_api/apps/indicator/views.py
+++ b/django_api/django_api/apps/indicator/views.py
@@ -643,10 +643,10 @@ class IndicatorLocationDataUpdateAPIView(APIView):
         HasAnyRole(
             PRP_ROLE_TYPES.ip_authorized_officer,
             PRP_ROLE_TYPES.ip_editor,
+            PRP_ROLE_TYPES.ip_admin,
             PRP_ROLE_TYPES.cluster_system_admin,
             PRP_ROLE_TYPES.cluster_imo,
             PRP_ROLE_TYPES.cluster_member,
-            PRP_ROLE_TYPES.ip_admin,
         )
     )
 

--- a/django_api/django_api/apps/indicator/views.py
+++ b/django_api/django_api/apps/indicator/views.py
@@ -646,6 +646,7 @@ class IndicatorLocationDataUpdateAPIView(APIView):
             PRP_ROLE_TYPES.cluster_system_admin,
             PRP_ROLE_TYPES.cluster_imo,
             PRP_ROLE_TYPES.cluster_member,
+            PRP_ROLE_TYPES.ip_admin,
         )
     )
 


### PR DESCRIPTION
### This PR completes [ch12109].

##### Feature list
* _Describe the list of features from Django_
  * Added missing IP Admin permissions to IndicatorLocationDataUpdateAPIView class in `views.py`. It was working before because even though the user's IP permissions were IP Admin (and no other IP permissions), they still had Cluster Member permissions as well, which allowed them to enter data.

##### Progress checker
- [x] Django