### PR TITLE
[ch13530] Fix progress display for percentage indicator

### DIFF
--- a/polymer/src/elements/etools-prp-progress-bar-alt.html
+++ b/polymer/src/elements/etools-prp-progress-bar-alt.html
@@ -17,7 +17,7 @@
       }
     </style>
 
-    <etools-prp-progress-bar number="[[number]]"></etools-prp-progress-bar>
+    <etools-prp-progress-bar display-type="[[displayType]]" number="[[number]]"></etools-prp-progress-bar>
   </template>
 
   <script>
@@ -25,6 +25,7 @@
       is: 'etools-prp-progress-bar-alt',
 
       properties: {
+        displayType: String,
         number: Number,
       },
     });

--- a/polymer/src/elements/etools-prp-progress-bar-cluster.html
+++ b/polymer/src/elements/etools-prp-progress-bar-cluster.html
@@ -17,7 +17,7 @@
       }
     </style>
 
-    <etools-prp-progress-bar number="[[number]]"></etools-prp-progress-bar>
+    <etools-prp-progress-bar display-type="[[displayType]]" number="[[number]]"></etools-prp-progress-bar>
   </template>
 
   <script>
@@ -25,6 +25,7 @@
       is: 'etools-prp-progress-bar-cluster',
 
       properties: {
+        displayType: String,
         number: Number,
       },
     });

--- a/polymer/src/elements/etools-prp-progress-bar.html
+++ b/polymer/src/elements/etools-prp-progress-bar.html
@@ -17,27 +17,31 @@
   </template>
 
   <script>
-    (function () {
-      Polymer({
-        is: 'etools-prp-progress-bar',
+    Polymer({
+      is: 'etools-prp-progress-bar',
 
-        properties: {
-          number: {
-            type: Number,
-            value: 0
-          },
-
-          percentage: {
-            type: Number,
-            computed: '_computePercentage(number)'
-          }
+      properties: {
+        displayType: {
+          type: String,
+          value: ''
         },
 
-        _computePercentage: function(num) {
-          return Math.round(num * 100);
-        }
+        number: {
+          type: Number,
+          value: 0
+        },
 
-      });
-    }());
+        percentage: {
+          type: Number,
+          computed: '_computePercentage(number)'
+        }
+      },
+
+      _computePercentage: function(num) {
+        console.log('displayType', this.displayType);
+        return Math.round(num * 100);
+      }
+
+    });
   </script>
 </dom-module>

--- a/polymer/src/elements/etools-prp-progress-bar.html
+++ b/polymer/src/elements/etools-prp-progress-bar.html
@@ -38,8 +38,7 @@
       },
 
       _computePercentage: function(num) {
-        console.log('displayType', this.displayType);
-        return Math.round(num * 100);
+        return this.displayType !== 'percentage' ? Math.round(num * 100) : Math.round(num);
       }
 
     });

--- a/polymer/src/elements/list-view-single-indicator.html
+++ b/polymer/src/elements/list-view-single-indicator.html
@@ -209,6 +209,7 @@
                   <dt class="flex-none self-center">[[localize('against_in_need')]]:</dt>
                   <dd class="flex-none">
                     <etools-prp-progress-bar-alt
+                        display-type="[[indicator.blueprint.display_type]]"
                         number="[[indicator.total_against_in_need]]">
                     </etools-prp-progress-bar-alt>
                   </dd>

--- a/polymer/src/elements/list-view-single-indicator.html
+++ b/polymer/src/elements/list-view-single-indicator.html
@@ -188,6 +188,7 @@
                     if="[[_equals(progressBarType, 'cluster')]]"
                     restamp="true">
                   <etools-prp-progress-bar-cluster
+                      display-type="[[indicator.bluepring.display_type]]"
                       number="[[indicator.total_against_target]]">
                   </etools-prp-progress-bar-cluster>
                 </template>
@@ -196,6 +197,7 @@
                     if="[[_equals(progressBarType, 'default')]]"
                     restamp="true">
                   <etools-prp-progress-bar
+                      display-type="[[indicator.blueprint.display_type]]"
                       number="[[indicator.total_against_target]]">
                   </etools-prp-progress-bar>
                 </template>
@@ -204,7 +206,7 @@
 
             <template is="dom-if" if="[[isClusterApp]]" restamp="true">
               <dl class="indicator-progress layout horizontal">
-                  <dt class="flex-none self-center">Against In need:</dt>
+                  <dt class="flex-none self-center">[[localize('against_in_need')]]:</dt>
                   <dd class="flex-none">
                     <etools-prp-progress-bar-alt
                         number="[[indicator.total_against_in_need]]">


### PR DESCRIPTION
### This PR completes [ch13530].

##### Feature list
* _Describe the list of features from Polymer_
  * Had the `list-view-single-indicator` component pass down the `indicator.blueprint.display_type` property for each indicator down to the `etools-prp-progress-bar` component and its alternate versions
  * Used the `displayType` prop to conditionally check if the number is already a percentage or not

##### Progress checker
- [x] Polymer