### PR TITLE
[ch13536] Remove localization from disaggregation labels

### DIFF
--- a/polymer/src/elements/disaggregations/disaggregation-table-row.html
+++ b/polymer/src/elements/disaggregations/disaggregation-table-row.html
@@ -15,7 +15,7 @@
 
     <tr class$="[[_computeClass(rowType)]]">
       <td class="cellTitle">
-        <span class="cellValue">[[_capitalizeFirstLetter(data.title, localize)]]</span>
+        <span class="cellValue">[[_capitalizeFirstLetter(data.title)]]</span>
       </td>
 
       <template is="dom-repeat"
@@ -134,7 +134,7 @@
       _computeClass: function (rowType) {
         return rowType;
       },
-
+      
       _setTotalEditable: function (coords, levelReported, editable) {
         this.set(
           'totalEditable',


### PR DESCRIPTION
### This PR completes [ch13536].

##### Feature list
* _Describe the list of features from Polymer_
  * Removed the localization that had been applied to the disaggregation labels in progress reports so that they can render properly

##### Progress checker
- [x] Polymer
