### PR TITLE
[ch13422] Correctly grab SR description

### DIFF
--- a/polymer/src/pages/app/ip-reporting/pd/pd-report-sr/reporting.html
+++ b/polymer/src/pages/app/ip-reporting/pd/pd-report-sr/reporting.html
@@ -238,7 +238,7 @@
           return reporting_period.report_type === 'SR' && new Date(reporting_period.due_date) <= new Date(progressReportDueDate);
         });
 
-        if (currentSrReport !== undefined) {
+        if (currentSrReport !== undefined && currentSrReport.description !== undefined) {
           return currentSrReport.description;
         } else {
           return '...';

--- a/polymer/src/pages/app/ip-reporting/pd/pd-report-sr/reporting.html
+++ b/polymer/src/pages/app/ip-reporting/pd/pd-report-sr/reporting.html
@@ -221,16 +221,19 @@
       },
 
       _computeSrDescription: function (pdId, programmeDocuments, allPdReports, reportId) {
+        // get the current progress report's due date
         var progressReportDueDate = allPdReports[pdId]
           .find(function (report) {
             return report.id === parseInt(reportId);
           })
           .due_date;
 
+        // get the current programme document
         var currentPdReport = programmeDocuments.find(function (report) {
           return report.id === pdId;
         });
 
+        // get the current SR reporting_period object from the current programme document's reporting_periods array
         var currentSrReport = currentPdReport.reporting_periods.find(function (reporting_period) {
           return reporting_period.report_type === 'SR' && new Date(reporting_period.due_date) <= new Date(progressReportDueDate);
         });

--- a/polymer/src/pages/app/ip-reporting/pd/pd-report-sr/reporting.html
+++ b/polymer/src/pages/app/ip-reporting/pd/pd-report-sr/reporting.html
@@ -60,7 +60,7 @@
       <div class="app-grid">
         <div class="row">
           <labelled-item label="[[localize('description')]]">
-            <span class="value">[[_withDefault(data.description)]]</span>
+            <span class="value">[[srDescription]]</span>
           </labelled-item>
         </div>
 
@@ -123,6 +123,16 @@
         pdId: {
           type: Number,
           statePath: 'programmeDocuments.current',
+        },
+
+        programmeDocuments: {
+          type: Array,
+          statePath: 'programmeDocuments.all'
+        },
+
+        srDescription: {
+          type: String,
+          computed: '_computeSrDescription(pdId, programmeDocuments)'
         },
 
         locationId: {
@@ -203,6 +213,25 @@
 
       _computeUpdateUrl: function (locationId, reportId) {
         return App.Endpoints.programmeDocumentReportUpdate(locationId, reportId);
+      },
+
+      _computeSrDescription: function (pdId, programmeDocuments) {
+        console.log('pdId', pdId);
+        console.log('programmeDocuments', programmeDocuments);
+
+        var currentPdReport = programmeDocuments.find(function (report) {
+          return report.id === pdId;
+        });
+
+        var currentSrReport = currentPdReport.reporting_periods.find(function (reporting_period) {
+          return reporting_period.report_type === 'SR' && reporting_period.programme_document === parseInt(pdId);
+        });
+
+        if (currentSrReport !== undefined) {
+          return currentSrReport.description;
+        } else {
+          return '...';
+        }
       },
 
       _computeMode: function (mode, overrideMode, report, permissions) {

--- a/polymer/src/pages/app/ip-reporting/pd/pd-report-sr/reporting.html
+++ b/polymer/src/pages/app/ip-reporting/pd/pd-report-sr/reporting.html
@@ -130,9 +130,14 @@
           statePath: 'programmeDocuments.all'
         },
 
+        allPdReports: {
+          type: Object,
+          statePath: 'programmeDocumentReports.byPD'
+        },
+
         srDescription: {
           type: String,
-          computed: '_computeSrDescription(pdId, programmeDocuments)'
+          computed: '_computeSrDescription(pdId, programmeDocuments, allPdReports, reportId)'
         },
 
         locationId: {
@@ -215,16 +220,27 @@
         return App.Endpoints.programmeDocumentReportUpdate(locationId, reportId);
       },
 
-      _computeSrDescription: function (pdId, programmeDocuments) {
+      _computeSrDescription: function (pdId, programmeDocuments, allPdReports, reportId) {
         console.log('pdId', pdId);
         console.log('programmeDocuments', programmeDocuments);
+        console.log('allPdReports', allPdReports);
+        console.log('reportId', reportId);
+
+        var progressReportDueDate = allPdReports[pdId]
+          .find(function (report) {
+            return report.id === parseInt(reportId);
+          })
+          .due_date;
+
+        console.log('progressReportDueDate', progressReportDueDate);
+        console.log('can compare dates?', new Date('31-Jul-2019') <= new Date(progressReportDueDate));
 
         var currentPdReport = programmeDocuments.find(function (report) {
           return report.id === pdId;
         });
 
         var currentSrReport = currentPdReport.reporting_periods.find(function (reporting_period) {
-          return reporting_period.report_type === 'SR' && reporting_period.programme_document === parseInt(pdId);
+          return reporting_period.report_type === 'SR' && new Date(reporting_period.due_date) <= new Date(progressReportDueDate);
         });
 
         if (currentSrReport !== undefined) {

--- a/polymer/src/pages/app/ip-reporting/pd/pd-report-sr/reporting.html
+++ b/polymer/src/pages/app/ip-reporting/pd/pd-report-sr/reporting.html
@@ -221,19 +221,11 @@
       },
 
       _computeSrDescription: function (pdId, programmeDocuments, allPdReports, reportId) {
-        console.log('pdId', pdId);
-        console.log('programmeDocuments', programmeDocuments);
-        console.log('allPdReports', allPdReports);
-        console.log('reportId', reportId);
-
         var progressReportDueDate = allPdReports[pdId]
           .find(function (report) {
             return report.id === parseInt(reportId);
           })
           .due_date;
-
-        console.log('progressReportDueDate', progressReportDueDate);
-        console.log('can compare dates?', new Date('31-Jul-2019') <= new Date(progressReportDueDate));
 
         var currentPdReport = programmeDocuments.find(function (report) {
           return report.id === pdId;


### PR DESCRIPTION
### This PR completes [ch13422].

##### Feature list
* _Describe the list of features from Polymer_
  * Make a new method in the SR `reporting.html` component that renders the correct SR description
  * Method grabs the current progress report's `due_date`, finds the current programme document report, finds the correct SR `reporting_period` object inside the current programme document report's `reporting_periods` array, checks that the reporting period's `due_date` is before or equal to the current progress report's `due_date`, and checks to make sure the reporting period's `report_type` property is correct ('SR').

##### Progress checker
- [x] Polymer