### PR TITLE
[ch13530] Fix percentage display in Indicator details expanded view

### DIFF
--- a/polymer/src/behaviors/utils.html
+++ b/polymer/src/behaviors/utils.html
@@ -129,11 +129,16 @@
           return value;
         }
 
+        console.log('indicatorType', indicatorType);
+
         var _value = value.toFixed(2);
+
+        console.log('_value', _value);
+        console.log('result?', percentize === 1 ? Math.floor(_value) + '%' : _value + '%');
 
         switch (indicatorType) {
           case 'percentage':
-            return percentize === 1 ? Math.floor(_value * 100) + '%' : _value + '%';
+            return percentize === 1 ? Math.floor(_value) + '%' : _value + '%';
           case 'ratio':
             return _value + ':1';
           default:

--- a/polymer/src/behaviors/utils.html
+++ b/polymer/src/behaviors/utils.html
@@ -129,12 +129,7 @@
           return value;
         }
 
-        console.log('indicatorType', indicatorType);
-
         var _value = value.toFixed(2);
-
-        console.log('_value', _value);
-        console.log('result?', percentize === 1 ? Math.floor(_value) + '%' : _value + '%');
 
         switch (indicatorType) {
           case 'percentage':


### PR DESCRIPTION
### This PR completes [ch13530].

##### Feature list
* _Describe the list of features from Polymer_
  * Fixed the `_formatIndicatorValue` method to round down the percentage value and no longer multiply it by 100 (because it was already being converted earlier in the method)

##### Progress checker
- [x] Polymer

- [x] Polymer test cases
