### PR TITLE
[ch14330] Add correct translation for enter_data label

### DIFF
--- a/polymer/src/locales.json
+++ b/polymer/src/locales.json
@@ -552,7 +552,7 @@
     "list_of_overdue_indicator":  "Liste des rapports d'indicateur en souffrance",
     "project":  "Projet",
     "activity":  "Activité",
-    "enter_data":  "Saisir la date",
+    "enter_data":  "Saisir les données",
     "location_progress_against_cluster":  "Progrès du site selon l'objectif du cluster",
     "submitted_list_constrained":  "Liste soumise de l'indicateur d'activité du partenaire limité",
     "last_reported":  "Dernier signalé",


### PR DESCRIPTION
### This PR completes [ch14330].

##### Feature list
* _Describe the list of features from Polymer_
  - Fixed translation for `enter_data` label to read "Saisir les données" rather than "Saisir la date"

##### Progress checker
- [x] Polymer