### PR TITLE
PDF export rendering fix for ratio value in IP reporting

### DIFF
--- a/django_api/django_api/apps/unicef/exports/programme_documents.py
+++ b/django_api/django_api/apps/unicef/exports/programme_documents.py
@@ -160,9 +160,11 @@ class ProgrammeDocumentsPDFExporter:
 
         for pd in self.programme_documents.order_by('id'):
             if pd.budget:
-                funds_received_to_date_percentage = int(round(pd.funds_received_to_date * 100 / pd.budget, 0))
+                funds_received_to_date_percentage = pd.funds_received_to_date_percentage
             else:
                 funds_received_to_date_percentage = 0
+
+            funds_received_to_date_percentage = "%.2f" % funds_received_to_date_percentage
 
             rows.append([
                 HTMLTableCell(pd.title, rowspan=5),

--- a/django_api/django_api/apps/unicef/exports/progress_reports.py
+++ b/django_api/django_api/apps/unicef/exports/progress_reports.py
@@ -117,8 +117,8 @@ class ProgressReportDetailPDFExporter:
         return tables
 
     def get_context(self):
-        funds_received_to_date_percentage = "%.1f" % (
-            self.progress_report.programme_document.funds_received_to_date * 100 / self.progress_report.programme_document.budget
+        funds_received_to_date_percentage = "%.2f" % (
+            self.progress_report.programme_document.funds_received_to_date_percentage
         ) if self.progress_report.programme_document and self.progress_report.programme_document.budget > 0 else 0
 
         context = {

--- a/django_api/django_api/apps/unicef/models.py
+++ b/django_api/django_api/apps/unicef/models.py
@@ -327,7 +327,7 @@ class ProgrammeDocument(TimeStampedExternalBusinessAreaModel):
 
     @property
     def funds_received_to_date_percentage(self):
-        return self.funds_received_to_date_percent
+        return self.funds_received_to_date_percent if self.funds_received_to_date_percent and self.funds_received_to_date_percent != -1 else 0
 
     @property
     def calculated_budget(self):

--- a/django_api/django_api/apps/unicef/templates/report_annex_c_pdf.html
+++ b/django_api/django_api/apps/unicef/templates/report_annex_c_pdf.html
@@ -157,7 +157,7 @@
                                 {% if indicator.is_number %}
                                     {{ indicator.total.v|floatformat:"0" }}
                                 {% elif indicator.reportable.blueprint.display_type == 'percentage' %}
-                                    {{ indicator.total.c }}%
+                                    {{ indicator.total.c|percent_format }}
                                 {% elif indicator.reportable.blueprint.display_type == 'ratio' %}
                                     {{ indicator.total.v }}/{{ indicator.total.d }}
                                 {% endif %}
@@ -190,7 +190,7 @@
                                 {% if indicator.is_number %}
                                     {{ indicator.total.v|floatformat:"0" }}
                                 {% elif indicator.reportable.blueprint.display_type == 'percentage' %}
-                                    {{ indicator.total.c }}%
+                                    {{ indicator.total.c|percent_format }}
                                 {% elif indicator.reportable.blueprint.display_type == 'ratio' %}
                                     {{ indicator.total.v }}/{{ indicator.total.d }}
                                 {% endif %}

--- a/django_api/django_api/apps/unicef/templatetags/pdf_extras.py
+++ b/django_api/django_api/apps/unicef/templatetags/pdf_extras.py
@@ -15,6 +15,14 @@ def percentage(value):
         return "N/A"
 
 
+@register.filter
+def percent_format(value):
+    try:
+        return "%.2f%%" % (float(value))
+    except ValueError:
+        return "N/A"
+
+
 @register.simple_tag(takes_context=True)
 def get_absolute_file_url(context, django_file, default='---'):
     request = context.get('request')

--- a/django_api/django_api/apps/unicef/views.py
+++ b/django_api/django_api/apps/unicef/views.py
@@ -339,8 +339,8 @@ class ProgressReportAnnexCPDFView(RetrieveAPIView):
     def get(self, request, *args, **kwargs):
         report = self.get_object()
 
-        funds_received_to_date_percentage = "%.1f" % (
-            report.programme_document.funds_received_to_date * 100 / report.programme_document.budget
+        funds_received_to_date_percentage = "%.2f" % (
+            report.programme_document.funds_received_to_date_percentage
         ) if report.programme_document and report.programme_document.budget > 0 else 0
 
         data = {


### PR DESCRIPTION
feat: Polished ratio value rendering in PDF export

+ funds_received_to_date_percentage to show 0 if percent value is None or -1

+ 2 decimal point rendering from funds_received_to_date_percentage in Annex-C PDF

+ 2 decimal point rendering from funds_received_to_date_percentage in ProgrammeDocument PDF export

+ 2 decimal point rendering from funds_received_to_date_percentage in ProgressReport List and Details PDF export

+ Ratio info formatting for target and baseline in Indicator list PDF export

+ new templatetag filter to percentize without scaling to 100% called percent_format

+ Used percent_format to render Reportable total correctly in Annex C PDF