### PR TITLE
Operational presence map fix and Cluster Indicator card fix

### DIFF
--- a/django_api/django_api/apps/indicator/serializers.py
+++ b/django_api/django_api/apps/indicator/serializers.py
@@ -1395,14 +1395,14 @@ class ClusterIndicatorSerializer(serializers.ModelSerializer):
             objective = get_object_or_404(ClusterObjective, pk=validated_data['object_id'])
             validated_data['is_cluster_indicator'] = True
 
-            if 'start_date_of_reporting_period' in validated_data \
+            if 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] < objective.response_plan.start:
                 error_msg = "Start date of reporting period cannot come before the response plan's start date"
 
                 raise ValidationError({
                     "start_date_of_reporting_period": error_msg,
                 })
-            elif 'start_date_of_reporting_period' in validated_data \
+            elif 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] > objective.response_plan.end:
                 error_msg = "Start date of reporting period cannot come after the response plan's end date"
 
@@ -1416,14 +1416,14 @@ class ClusterIndicatorSerializer(serializers.ModelSerializer):
             activity = get_object_or_404(ClusterActivity, pk=validated_data['object_id'])
             validated_data['is_cluster_indicator'] = True
 
-            if 'start_date_of_reporting_period' in validated_data \
+            if 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] < activity.response_plan.start:
                 error_msg = "Start date of reporting period cannot come before the response plan's start date"
 
                 raise ValidationError({
                     "start_date_of_reporting_period": error_msg,
                 })
-            elif 'start_date_of_reporting_period' in validated_data \
+            elif 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] > activity.response_plan.end:
                 error_msg = "Start date of reporting period cannot come after the response plan's end date"
 
@@ -1437,14 +1437,14 @@ class ClusterIndicatorSerializer(serializers.ModelSerializer):
             content_object = get_object_or_404(PartnerProject, pk=validated_data['object_id'])
             validated_data['is_cluster_indicator'] = False
 
-            if 'start_date_of_reporting_period' in validated_data \
+            if 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] < content_object.start_date:
                 error_msg = "Start date of reporting period cannot come before the project's start date"
 
                 raise ValidationError({
                     "start_date_of_reporting_period": error_msg,
                 })
-            elif 'start_date_of_reporting_period' in validated_data \
+            elif 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] > content_object.end_date:
                 error_msg = "Start date of reporting period cannot come after the project's end date"
 
@@ -1466,14 +1466,14 @@ class ClusterIndicatorSerializer(serializers.ModelSerializer):
             project_context = get_object_or_404(PartnerActivityProjectContext, pk=validated_data.pop('project_context_id'))
             content_object = project_context
 
-            if 'start_date_of_reporting_period' in validated_data \
+            if 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] < project_context.start_date:
                 error_msg = "Start date of reporting period cannot come before the activity project context's start date"
 
                 raise ValidationError({
                     "start_date_of_reporting_period": error_msg,
                 })
-            elif 'start_date_of_reporting_period' in validated_data \
+            elif 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] > project_context.end_date:
                 error_msg = "Start date of reporting period cannot come after the project context's end date"
 
@@ -1542,16 +1542,17 @@ class ClusterIndicatorSerializer(serializers.ModelSerializer):
 
         if reportable_object_content_model == ClusterObjective:
             objective = get_object_or_404(ClusterObjective, pk=validated_data['object_id'])
+            content_object = objective
             validated_data['is_cluster_indicator'] = True
 
-            if 'start_date_of_reporting_period' in validated_data \
+            if 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] < objective.response_plan.start:
                 error_msg = "Start date of reporting period cannot come before the response plan's start date"
 
                 raise ValidationError({
                     "start_date_of_reporting_period": error_msg,
                 })
-            elif 'start_date_of_reporting_period' in validated_data \
+            elif 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] > objective.response_plan.end:
                 error_msg = "Start date of reporting period cannot come after the response plan's end date"
 
@@ -1563,16 +1564,17 @@ class ClusterIndicatorSerializer(serializers.ModelSerializer):
 
         elif reportable_object_content_model == ClusterActivity:
             activity = get_object_or_404(ClusterActivity, pk=validated_data['object_id'])
+            content_object = activity
             validated_data['is_cluster_indicator'] = True
 
-            if 'start_date_of_reporting_period' in validated_data \
+            if 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] < activity.response_plan.start:
                 error_msg = "Start date of reporting period cannot come before the response plan's start date"
 
                 raise ValidationError({
                     "start_date_of_reporting_period": error_msg,
                 })
-            elif 'start_date_of_reporting_period' in validated_data \
+            elif 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] > activity.response_plan.end:
                 error_msg = "Start date of reporting period cannot come after the response plan's end date"
 
@@ -1585,7 +1587,7 @@ class ClusterIndicatorSerializer(serializers.ModelSerializer):
         elif reportable_object_content_model == PartnerProject:
             content_object = get_object_or_404(PartnerProject, pk=validated_data['object_id'])
 
-            if 'start_date_of_reporting_period' in validated_data \
+            if 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] < content_object.start_date:
                 error_msg = "Start date of reporting period cannot come before the project's start date"
 
@@ -1593,7 +1595,7 @@ class ClusterIndicatorSerializer(serializers.ModelSerializer):
                     "start_date_of_reporting_period": error_msg,
                 })
 
-            elif 'start_date_of_reporting_period' in validated_data \
+            elif 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] > content_object.end_date:
                 error_msg = "Start date of reporting period cannot come after the project's end date"
 
@@ -1612,7 +1614,7 @@ class ClusterIndicatorSerializer(serializers.ModelSerializer):
             project_context = get_object_or_404(PartnerActivityProjectContext, pk=validated_data.pop('project_context_id'))
             content_object = project_context
 
-            if 'start_date_of_reporting_period' in validated_data \
+            if 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] < project_context.start_date:
                 error_msg = "Start date of reporting period cannot come before the activity project context's start date"
 
@@ -1620,7 +1622,7 @@ class ClusterIndicatorSerializer(serializers.ModelSerializer):
                     "start_date_of_reporting_period": error_msg,
                 })
 
-            elif 'start_date_of_reporting_period' in validated_data \
+            elif 'start_date_of_reporting_period' in validated_data and validated_data['start_date_of_reporting_period'] \
                     and validated_data['start_date_of_reporting_period'] > project_context.end_date:
                 error_msg = "Start date of reporting period cannot come after the project context's end date"
 
@@ -2346,10 +2348,15 @@ class ClusterAnalysisIndicatorDetailSerializer(serializers.ModelSerializer):
             ),
         }
 
-        if reportable.content_object.activity.partner.title not in partner_progresses:
-            partner_progresses[reportable.content_object.activity.partner.title] = list()
+        if isinstance(reportable.content_object, PartnerActivityProjectContext):
+            partner_title = reportable.content_object.activity.partner.title
+        else:
+            partner_title = reportable.content_object.partner.title
 
-        partner_progresses[reportable.content_object.activity.partner.title].append(data)
+        if partner_title not in partner_progresses:
+            partner_progresses[partner_title] = list()
+
+        partner_progresses[partner_title].append(data)
 
     def get_current_progress_by_partner(self, obj):
         partner_progresses = {}

--- a/django_api/django_api/apps/partner/serializers.py
+++ b/django_api/django_api/apps/partner/serializers.py
@@ -52,6 +52,8 @@ class PartnerSimpleSerializer(serializers.ModelSerializer):
 class PartnerActivityProjectContextSerializer(serializers.ModelSerializer):
     project_id = serializers.IntegerField(source="id")
     project_name = serializers.SerializerMethodField()
+    activity_name = serializers.SerializerMethodField()
+    cluster_objective_name = serializers.SerializerMethodField()
     context_id = serializers.IntegerField(source="id", read_only=True)
     start_date = serializers.DateField()
     end_date = serializers.DateField()
@@ -63,13 +65,21 @@ class PartnerActivityProjectContextSerializer(serializers.ModelSerializer):
             'project_id',
             'context_id',
             'project_name',
+            'activity_name',
+            'cluster_objective_name',
             'start_date',
             'end_date',
             'status',
         )
 
     def get_project_name(self, obj):
-        return obj.project.title if getattr(obj, 'project', None) else obj.title
+        return obj.project.title
+
+    def get_activity_name(self, obj):
+        return obj.activity.title
+
+    def get_cluster_objective_name(self, obj):
+        return obj.activity.cluster_objective.title if obj.activity.cluster_objective else obj.activity.cluster_activity.cluster_objective.title
 
 
 class PartnerActivityProjectContextDetailUpdateSerializer(PartnerActivityProjectContextSerializer):

--- a/polymer/src/elements/cluster-reporting/analysis/indicator-bucket.html
+++ b/polymer/src/elements/cluster-reporting/analysis/indicator-bucket.html
@@ -219,7 +219,6 @@
       },
 
       _computeIndicatorTitle: function (data) {
-        console.log('data :', data);
         return data.type === 'partneractivityprojectcontext' ? data.activity_name : data.title;
       },
 

--- a/polymer/src/elements/cluster-reporting/analysis/indicator-bucket.html
+++ b/polymer/src/elements/cluster-reporting/analysis/indicator-bucket.html
@@ -48,6 +48,25 @@
         color: var(--theme-primary-text-color-medium);
       }
 
+      .partner-project {
+        margin: 0;
+        padding-top: 0px;
+        padding-left: 25px;
+        padding-right: 25px;
+        padding-bottom: 25px;
+        font-size: 12px;
+      }
+
+      .partner-project dt,
+      .partner-project dd {
+        display: inline;
+        margin: 0;
+      }
+
+      .partner-project dt {
+        color: var(--theme-primary-text-color-medium);
+      }
+
       .indicator {
         padding: 5px 12px;
         background: var(--paper-grey-300);
@@ -99,6 +118,17 @@
         <dt>Cluster Objective:</dt>
         <dd>[[_computeObjectiveTitle(data)]]</dd>
       </dl>
+
+      <template
+        is="dom-if"
+        if="[[_computePartnerProjectTitle(data)]]"
+        restamp="true"
+      >
+        <dl class="partner-project">
+          <dt>Partner Project:</dt>
+          <dd>[[_computePartnerProjectTitle(data)]]</dd>
+        </dl>
+      </template>
 
       <template
           is="dom-repeat"
@@ -174,14 +204,23 @@
 
       _computeObjectiveTitle: function (data) {
         if (data.type === 'partneractivityprojectcontext') {
-          return data.project_name;
+          return data.cluster_objective_name;
         } else {
           return data.cluster_objective_title === undefined ? data.title : data.cluster_objective_title;
         }
       },
 
+      _computePartnerProjectTitle: function (data) {
+        if (data.type === 'partneractivityprojectcontext') {
+          return data.project_name;
+        } else {
+          return undefined;
+        }
+      },
+
       _computeIndicatorTitle: function (data) {
-        return data.type === 'partneractivityprojectcontext' ? data.project_name : data.title;
+        console.log('data :', data);
+        return data.type === 'partneractivityprojectcontext' ? data.activity_name : data.title;
       },
 
       _computePrefix: function (data) {

--- a/polymer/src/elements/cluster-reporting/analysis/indicator-bucket.html
+++ b/polymer/src/elements/cluster-reporting/analysis/indicator-bucket.html
@@ -94,10 +94,10 @@
       }
     </style>
 
-    <etools-content-panel panel-title="[[prefix]] [[data.title]]">
+    <etools-content-panel panel-title="[[prefix]] [[_computeIndicatorTitle(data)]]">
       <dl class="cluster-objective">
         <dt>Cluster Objective:</dt>
-        <dd>[[_computeTitle(data)]]</dd>
+        <dd>[[_computeObjectiveTitle(data)]]</dd>
       </dl>
 
       <template
@@ -172,8 +172,16 @@
         this.$$('#collapse-' + e.target.toggles).toggle();
       },
 
-      _computeTitle: function (data) {
-        return data.cluster_objective_title === undefined ? data.title : data.cluster_objective_title;
+      _computeObjectiveTitle: function (data) {
+        if (data.type === 'partneractivityprojectcontext') {
+          return data.project_name;
+        } else {
+          return data.cluster_objective_title === undefined ? data.title : data.cluster_objective_title;
+        }
+      },
+
+      _computeIndicatorTitle: function (data) {
+        return data.type === 'partneractivityprojectcontext' ? data.project_name : data.title;
       },
 
       _computePrefix: function (data) {
@@ -182,6 +190,7 @@
           partnerproject: 'Partner Project',
           clusterobjective: 'Cluster Objective',
           clusteractivity: 'Cluster Activity',
+          partneractivityprojectcontext: 'Partner Activity (w/Project Context)',
         }[data.type];
 
         return prefix ? prefix + ':' : '';

--- a/polymer/src/elements/cluster-reporting/analysis/operational-presence-map.html
+++ b/polymer/src/elements/cluster-reporting/analysis/operational-presence-map.html
@@ -156,6 +156,8 @@
       ],
 
       properties: {
+        currentWorkspaceCoords: Array,
+
         loading: {
           type: Boolean,
           statePath: 'analysis.operationalPresence.mapLoading',
@@ -247,7 +249,25 @@
           type: Boolean,
           value: false,
         },
+
+        currentWorkspaceCode: {
+          type: String,
+          statePath: 'workspaces.current'
+        },
+
+        allWorkspaces: {
+          type: Array,
+          statePath: 'workspaces.all'
+        },
+
+        currentWorkspaceCoords: {
+          type: Array
+        }
       },
+
+      observers: [
+        '_setCurrentWorkspaceCoords(allWorkspaces, currentWorkspaceCode)'
+      ],
 
       _computeTileUrl: function (accessToken) {
         return [
@@ -255,6 +275,14 @@
           '?access_token=',
           accessToken,
         ].join('');
+      },
+
+      _setCurrentWorkspaceCoords: function (all, currentCode) {
+        var currentWorkspace = all.find(function (workspace) {
+          return workspace.code === currentCode;
+        });
+
+        this.set('currentWorkspaceCoords', [currentWorkspace.longitude, currentWorkspace.latitude]);
       },
 
       _getLegendIndex: function (properties, legend) {
@@ -314,7 +342,10 @@
               return feature.geometry.coordinates;
             })
             .forEach(traverse);
-
+        
+        if (map.features.length === 0) {
+          return this.currentWorkspaceCoords;
+        }
         return [
           minLon + (maxLon - minLon) / 2,
           minLat + (maxLat - minLat) / 2,

--- a/polymer/src/redux/actions.html
+++ b/polymer/src/redux/actions.html
@@ -109,6 +109,8 @@
                     id: workspace.id,
                     code: workspace.workspace_code,
                     name: workspace.title,
+                    latitude: workspace.latitude,
+                    longitude: workspace.longitude
                   };
                 });
 


### PR DESCRIPTION
### This PR completes two bugs on the Analysis tab - the operational presence map and the cluster indicator card.

##### Feature list
* _Describe the list of features from Polymer_
  - Added an observer method for getting the lat/long of a workspace and, if the map is empty, setting the map to center on the workspace.
  - Added conditional logic to correctly render titles of indicator cards that were of type `partneractivityprojectcontext`

##### Screenshots:
**Map**:
![Screen Shot 2019-10-24 at 3 42 41 PM](https://user-images.githubusercontent.com/27440940/67532898-edf2ca00-f67c-11e9-8706-05303129ac6d.png)

**Indicator card**:
![Screen Shot 2019-10-24 at 4 35 07 PM](https://user-images.githubusercontent.com/27440940/67532910-fc40e600-f67c-11e9-86fd-9fd010fbd9b4.png)
