### PR TITLE
[ch16546] Fix arrow keys from navigating radio buttons in certain modals

### DIFF
--- a/polymer/src/elements/cluster-reporting/add-response-plan-modal.html
+++ b/polymer/src/elements/cluster-reporting/add-response-plan-modal.html
@@ -8,7 +8,6 @@
 <link rel="import" href="../../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../../../bower_components/app-layout/app-grid/app-grid-style.html">
-<link rel="import" href="../../../bower_components/paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../../../bower_components/paper-radio-button/paper-radio-button.html">
 <link rel="import" href="../../../bower_components/etools-loading/etools-loading.html">
 <link rel="import" href="../../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
@@ -35,6 +34,7 @@
 <link rel="import" href="../../redux/selectors/workspace.html">
 <link rel="import" href="./response-plan-details.html">
 <link rel="import" href="../error-box.html">
+<link rel="import" href="paper-radio-group-custom.html">
 
 
 <dom-module id="add-response-plan-modal">
@@ -63,20 +63,20 @@
         position: relative;
       }
 
-      paper-radio-group {
+      paper-radio-group-custom {
         display: block;
         padding-top: 16px;
       }
 
-      paper-radio-group > .fields {
+      paper-radio-group-custom > .fields {
         padding: calc(var(--app-grid-gutter) / 2) 0;
       }
 
-      paper-radio-group > .fields[empty] {
+      paper-radio-group-custom > .fields[empty] {
         padding: 0;
       }
 
-      paper-radio-group .app-grid {
+      paper-radio-group-custom .app-grid {
         margin: -var(--app-grid-gutter);
       }
 
@@ -133,7 +133,7 @@
 
       <paper-dialog-scrollable>
         <error-box errors="[[errors]]"></error-box>
-        <paper-radio-group
+        <paper-radio-group-custom
           id="mode"
           selected="{{ mode }}">
           <paper-radio-button name="ocha">
@@ -254,7 +254,7 @@
               </div>
             </template>
           </div>
-        </paper-radio-group>
+        </paper-radio-group-custom>
       </paper-dialog-scrollable>
 
       <div class="buttons layout horizontal-reverse">

--- a/polymer/src/elements/cluster-reporting/planned-action/activities/add-activity-from-project-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/activities/add-activity-from-project-modal.html
@@ -8,7 +8,6 @@
 <link rel="import" href="../../../../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../../../../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../../../../../bower_components/app-layout/app-grid/app-grid-style.html">
-<link rel="import" href="../../../../../bower_components/paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../../../../../bower_components/paper-radio-button/paper-radio-button.html">
 <link rel="import" href="../../../../../bower_components/etools-loading/etools-loading.html">
 <link rel="import" href="../../../../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
@@ -31,6 +30,7 @@
 <link rel="import" href="../../../form-fields/partner-dropdown-content.html">
 <link rel="import" href="../../../form-fields/cluster-dropdown-content.html">
 <link rel="import" href="../../../error-box.html">
+<link rel="import" href="../../paper-radio-group-custom.html">
 
 <dom-module id="planned-action-add-activity-from-project-modal">
   <template>
@@ -103,20 +103,20 @@
         border-right: 1px solid var(--paper-grey-400);
       }
 
-      paper-radio-group {
+      paper-radio-group-custom {
         display: block;
         padding-top: 16px;
       }
 
-      paper-radio-group > .fields {
+      paper-radio-group-custom > .fields {
         padding: calc(var(--app-grid-gutter) / 2) 0;
       }
 
-      paper-radio-group > .fields[empty] {
+      paper-radio-group-custom > .fields[empty] {
         padding: 0;
       }
 
-      paper-radio-group .app-grid {
+      paper-radio-group-custom .app-grid {
         margin: -var(--app-grid-gutter);
       }
 
@@ -188,7 +188,7 @@
       <paper-dialog-scrollable>
         <error-box errors="[[errors]]"></error-box>
 
-        <paper-radio-group
+        <paper-radio-group-custom
             id="mode"
             selected="{{mode}}">
           <paper-radio-button name="cluster">
@@ -457,7 +457,7 @@
               </div>
             </template>
           </div>
-        </paper-radio-group>
+        </paper-radio-group-custom>
       </paper-dialog-scrollable>
 
       <div class="buttons layout horizontal-reverse">

--- a/polymer/src/elements/cluster-reporting/planned-action/activities/add-existing-activity-from-project-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/activities/add-existing-activity-from-project-modal.html
@@ -8,7 +8,6 @@
 <link rel="import" href="../../../../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../../../../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../../../../../bower_components/app-layout/app-grid/app-grid-style.html">
-<link rel="import" href="../../../../../bower_components/paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../../../../../bower_components/paper-radio-button/paper-radio-button.html">
 <link rel="import" href="../../../../../bower_components/etools-loading/etools-loading.html">
 <link rel="import" href="../../../../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">

--- a/polymer/src/elements/cluster-reporting/planned-action/activities/creation-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/activities/creation-modal.html
@@ -8,7 +8,6 @@
 <link rel="import" href="../../../../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../../../../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../../../../../bower_components/app-layout/app-grid/app-grid-style.html">
-<link rel="import" href="../../../../../bower_components/paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../../../../../bower_components/paper-radio-button/paper-radio-button.html">
 <link rel="import" href="../../../../../bower_components/etools-loading/etools-loading.html">
 <link rel="import" href="../../../../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
@@ -31,6 +30,7 @@
 <link rel="import" href="../../../form-fields/partner-dropdown-content.html">
 <link rel="import" href="../../../form-fields/cluster-dropdown-content.html">
 <link rel="import" href="../../../error-box.html">
+<link rel="import" href="../../paper-radio-group-custom.html">
 
 <dom-module id="planned-action-activity-modal">
   <template>
@@ -103,20 +103,20 @@
         border-right: 1px solid var(--paper-grey-400);
       }
 
-      paper-radio-group {
+      paper-radio-group-custom {
         display: block;
         padding-top: 16px;
       }
 
-      paper-radio-group > .fields {
+      paper-radio-group-custom > .fields {
         padding: calc(var(--app-grid-gutter) / 2) 0;
       }
 
-      paper-radio-group > .fields[empty] {
+      paper-radio-group-custom > .fields[empty] {
         padding: 0;
       }
 
-      paper-radio-group .app-grid {
+      paper-radio-group-custom .app-grid {
         margin: -var(--app-grid-gutter);
       }
 
@@ -204,7 +204,7 @@
           </etools-single-selection-menu>
         </template>
 
-        <paper-radio-group
+        <paper-radio-group-custom
             id="mode"
             selected="{{mode}}">
           <paper-radio-button name="cluster">
@@ -512,7 +512,7 @@
               </div>
             </template>
           </div>
-        </paper-radio-group>
+        </paper-radio-group-custom>
       </paper-dialog-scrollable>
 
       <div class="buttons layout horizontal-reverse">

--- a/polymer/src/elements/cluster-reporting/planned-action/activities/editing-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/activities/editing-modal.html
@@ -8,7 +8,6 @@
 <link rel="import" href="../../../../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../../../../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../../../../../bower_components/app-layout/app-grid/app-grid-style.html">
-<link rel="import" href="../../../../../bower_components/paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../../../../../bower_components/paper-radio-button/paper-radio-button.html">
 <link rel="import" href="../../../../../bower_components/etools-loading/etools-loading.html">
 <link rel="import" href="../../../../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">

--- a/polymer/src/elements/cluster-reporting/planned-action/projects/creation-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/projects/creation-modal.html
@@ -15,7 +15,7 @@
       href="../../../../../bower_components/etools-searchable-multiselection-menu/etools-multi-selection-menu.html">
 <link rel="import"
       href="../../../../../bower_components/etools-searchable-multiselection-menu/etools-single-selection-menu.html">
-<link rel="import" href="../../../../../bower_components/paper-radio-group/paper-radio-group.html">
+<!-- <link rel="import" href="../../../../../bower_components/paper-radio-group/paper-radio-group.html"> -->
 <link rel="import" href="../../../../../bower_components/paper-radio-button/paper-radio-button.html">
 
 <link rel="import" href="../../../../../bower_components/paper-input/paper-input.html">
@@ -43,6 +43,7 @@
 <link rel="import" href="../../../labelled-item.html">
 <link rel="import" href="../../../error-box.html">
 <link rel="import" href="../../indicator-locations-widget.html">
+<link rel="import" href="../../paper-radio-group-custom.html">
 
 
 <dom-module id="planned-action-projects-modal">
@@ -148,20 +149,20 @@
         display: none !important;
       }
 
-      paper-radio-group {
+      paper-radio-group-custom {
         display: block;
         padding-top: 16px;
       }
 
-      paper-radio-group > .fields {
+      paper-radio-group-custom > .fields {
         padding: calc(var(--app-grid-gutter) / 2) 0;
       }
 
-      paper-radio-group > .fields[empty] {
+      paper-radio-group-custom > .fields[empty] {
         padding: 0;
       }
 
-      paper-radio-group .app-grid {
+      paper-radio-group-custom .app-grid {
         margin: -var(--app-grid-gutter);
       }
 
@@ -271,7 +272,7 @@
               </etools-single-selection-menu>
             </template>
           </template>
-          <paper-radio-group
+          <paper-radio-group-custom
             id="mode"
             selected="{{ mode }}"
             on-change="adjustPosition">
@@ -528,12 +529,12 @@
 
                         <div class="full-width">
                           <labelled-item label="[[localize('is_this_project_hrp_fa')]]">
-                            <paper-radio-group
+                            <paper-radio-group-custom
                               selected="{{ data.part }}">
                               <paper-radio-button name="hrp">HRP</paper-radio-button>
                               <paper-radio-button name="fa">FA</paper-radio-button>
                               <paper-radio-button name="no">[[localize('no')]]</paper-radio-button>
-                            </paper-radio-group>
+                            </paper-radio-group-custom>
                           </labelled-item>
                         </div>
 
@@ -678,16 +679,11 @@
 
               <etools-loading active="[[updatePending]]"></etools-loading>
 
-
             </div>
+          </paper-radio-group-custom>
         </template>
-        </div>
-        </paper-radio-group>
-  </template>
-  </paper-dialog-scrollable>
-
-
-  </paper-dialog>
+      </paper-dialog-scrollable>
+    </paper-dialog>
   </template>
 
   <script>

--- a/polymer/src/elements/cluster-reporting/planned-action/projects/creation-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/projects/creation-modal.html
@@ -972,6 +972,7 @@
           this.set('refresh', false);
           this.set('detailsOpened', false);
           this.set('errors', {});
+          this.set('mode', '');
 
           this.close();
         } else {

--- a/polymer/src/elements/cluster-reporting/planned-action/projects/creation-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/projects/creation-modal.html
@@ -15,7 +15,6 @@
       href="../../../../../bower_components/etools-searchable-multiselection-menu/etools-multi-selection-menu.html">
 <link rel="import"
       href="../../../../../bower_components/etools-searchable-multiselection-menu/etools-single-selection-menu.html">
-<!-- <link rel="import" href="../../../../../bower_components/paper-radio-group/paper-radio-group.html"> -->
 <link rel="import" href="../../../../../bower_components/paper-radio-button/paper-radio-button.html">
 
 <link rel="import" href="../../../../../bower_components/paper-input/paper-input.html">


### PR DESCRIPTION
### This PR completes [ch16546].

##### Feature list
* _Describe the list of features from Polymer_
  - Replaced the default `paper-radio-group` component with a custom one for all applicable components
  - The custom `paper-radio-group` component has no listeners attached to the arrow keys, so the arrow keys function as normal when typing text in a field under a radio button option.
  - Cleaned up code and removed unused imports

##### Screenshots:
![arrow_keys](https://user-images.githubusercontent.com/27440940/68705144-604f1f80-0542-11ea-8c29-c469cc02431f.gif)

