### PR TITLE
[ch16602] Resolve issue with being unable to add a Cluster IMO user

### DIFF
--- a/react/id_management_frontend/src/components/Users/AddPermissionsDialog.jsx
+++ b/react/id_management_frontend/src/components/Users/AddPermissionsDialog.jsx
@@ -24,7 +24,13 @@ export class AddPermissionsDialog extends Component {
         this.onClose = this.onClose.bind(this);
         this.onSubmit = this.onSubmit.bind(this);
 
-        props.dispatchFetchClustersForPartner(props.user.partner.id)
+        console.log('props', props);
+
+        if (!props.user.partner) {
+            props.dispatchFetchClusters();
+        } else {
+            props.dispatchFetchClustersForPartner(props.user.partner.id)
+        }
     }
 
     onSubmit(values) {
@@ -84,12 +90,14 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = dispatch => {
     return {
         dispatchFetchClustersForPartner: (partner_id) => dispatch(fetch(FETCH_OPTIONS.CLUSTERS_FOR_PARTNER, partner_id)),
+        dispatchFetchClusters: () => dispatch(fetch(FETCH_OPTIONS.CLUSTERS)),
     }
 };
 
 AddPermissionsDialog.propTypes = {
     error: PropTypes.string,
     handleSubmit: PropTypes.func.isRequired,
+    dispatchFetchClusters: PropTypes.func.isRequired,
     dispatchFetchClustersForPartner: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,

--- a/react/id_management_frontend/src/components/Users/AddPermissionsDialog.jsx
+++ b/react/id_management_frontend/src/components/Users/AddPermissionsDialog.jsx
@@ -24,8 +24,6 @@ export class AddPermissionsDialog extends Component {
         this.onClose = this.onClose.bind(this);
         this.onSubmit = this.onSubmit.bind(this);
 
-        console.log('props', props);
-
         if (!props.user.partner) {
             props.dispatchFetchClusters();
         } else {

--- a/react/id_management_frontend/src/components/Users/renderPermissionsFields.jsx
+++ b/react/id_management_frontend/src/components/Users/renderPermissionsFields.jsx
@@ -13,7 +13,7 @@ import {userRoleInCluster, userRoleInWorkspace} from "../../helpers/user";
 import {PORTALS} from "../../actions";
 import {filterOptionsValues} from "../../helpers/options";
 import withProps from "../hoc/withProps";
-import {clusterForPartnerOptions, portal, user, workspaceOptions} from "../../helpers/props";
+import {clusterForPartnerOptions, clusterOptions, portal, user, workspaceOptions} from "../../helpers/props";
 
 const title = {
     [PORTALS.IP]: "Role per Workspace",
@@ -32,15 +32,22 @@ const getSelectedOptions = (optionName, fields, index) => {
     return options;
 };
 
-const renderPermissionsFields = ({selectedUser, fields, portal, workspaceOptions, user, clusterForPartnerOptions}) => {
+const renderPermissionsFields = ({selectedUser, fields, portal, workspaceOptions, user, clusterForPartnerOptions, clusterOptions}) => {
     let showAdd;
 
     if (portal === PORTALS.IP) {
         showAdd = fields.length < workspaceOptions.length;
     }
-    else {
+    else if (clusterForPartnerOptions.length) {
         showAdd = fields.length < clusterForPartnerOptions.length;
+    } else {
+        showAdd = fields.length < clusterOptions.length;
     }
+
+    console.log('clusterForPartnerOptions', clusterForPartnerOptions);
+    console.log('clusterOptions', clusterOptions);
+
+    console.log('fields', fields);
 
     return (
         <div>
@@ -54,6 +61,7 @@ const renderPermissionsFields = ({selectedUser, fields, portal, workspaceOptions
                     const selectedWorkspaces = getSelectedOptions("workspace", fields, index);
                     const filteredWorkspaceOptions = filterOptionsValues(workspaceOptions, selectedWorkspaces);
                     const filteredClusterOptions = filterOptionsValues(clusterForPartnerOptions, selectedClusters);
+                    const filteredClusters = filterOptionsValues(clusterOptions, selectedClusters);
 
                     let role;
 
@@ -94,9 +102,13 @@ const renderPermissionsFields = ({selectedUser, fields, portal, workspaceOptions
                                                       options={filteredWorkspaceOptions}
                                                       maxMenuHeight={maxMenuHeight}/>}
 
-                                    {portal === PORTALS.CLUSTER &&
+                                    {portal === PORTALS.CLUSTER && clusterForPartnerOptions.length > 0 &&
                                     <SearchSelectForm fieldName={`${item}.cluster`} label={labels.cluster}
                                                       options={filteredClusterOptions} maxMenuHeight={maxMenuHeight}/>}
+
+                                    {portal === PORTALS.CLUSTER && clusterOptions.length > 0 &&
+                                    <SearchSelectForm fieldName={`${item}.cluster`} label={labels.cluster}
+                                                      options={filteredClusters} maxMenuHeight={maxMenuHeight}/>}
                                 </Grid>
 
                                 <Grid item md={6}>
@@ -121,9 +133,10 @@ renderPermissionsFields.propTypes = {
     portal: PropTypes.string,
     selectedUser: PropTypes.object,
     clusterForPartnerOptions: PropTypes.array.isRequired,
+    clusterOptions: PropTypes.array.isRequired,
     user: PropTypes.object,
     workspaceOptions: PropTypes.array
 };
 
-export default withProps(clusterForPartnerOptions, workspaceOptions, portal, user)(renderPermissionsFields);
+export default withProps(clusterForPartnerOptions, clusterOptions, workspaceOptions, portal, user)(renderPermissionsFields);
 

--- a/react/id_management_frontend/src/components/Users/renderPermissionsFields.jsx
+++ b/react/id_management_frontend/src/components/Users/renderPermissionsFields.jsx
@@ -44,11 +44,6 @@ const renderPermissionsFields = ({selectedUser, fields, portal, workspaceOptions
         showAdd = fields.length < clusterOptions.length;
     }
 
-    console.log('clusterForPartnerOptions', clusterForPartnerOptions);
-    console.log('clusterOptions', clusterOptions);
-
-    console.log('fields', fields);
-
     return (
         <div>
             <Typography variant="caption" gutterBottom>{title[portal]}</Typography>


### PR DESCRIPTION
# This PR completes [ch16602].

### Feature list
* _Describe the list of features from React_
  - Added back vanilla clusterOptions (which had been modified in PR #1218 to account for clusters for partner) in order to fall back to in case partner wasn't applicable, like when creating an IMO user
  - Cleaned up unnecessary code and console logs

### Screenshots:
![cluster_imo_creation](https://user-images.githubusercontent.com/27440940/68816928-e5b2fc80-0634-11ea-842a-3187b90cba5a.gif)
