### PR TITLE
[ch16984] Enable/disable CSO type field depending on Partner type value

### DIFF
--- a/react/id_management_frontend/src/components/Partners/PartnerDialog.jsx
+++ b/react/id_management_frontend/src/components/Partners/PartnerDialog.jsx
@@ -53,12 +53,13 @@ class PartnerDialog extends Component {
     onClose() {
         const {reset, onClose} = this.props;
 
+        this.setState({ csoSelected: false });
+
         onClose();
         reset();
     }
 
     handleChange(e) {
-        console.log('e.target.value', e.target.value);
         if (e.target.value === 'CSO') {
             this.setState({ csoSelected: true });
         } else {

--- a/react/id_management_frontend/src/components/Partners/PartnerDialog.jsx
+++ b/react/id_management_frontend/src/components/Partners/PartnerDialog.jsx
@@ -24,11 +24,13 @@ class PartnerDialog extends Component {
         super(props);
 
         this.state = {
-            loading: false
+            loading: false,
+            csoSelected: false
         };
 
         this.onClose = this.onClose.bind(this);
         this.onSubmit = this.onSubmit.bind(this);
+        this.handleChange = this.handleChange.bind(this);
     }
 
     onSubmit(values) {
@@ -53,6 +55,15 @@ class PartnerDialog extends Component {
 
         onClose();
         reset();
+    }
+
+    handleChange(e) {
+        console.log('e.target.value', e.target.value);
+        if (e.target.value === 'CSO') {
+            this.setState({ csoSelected: true });
+        } else {
+            this.setState({ csoSelected: false });
+        }
     }
 
     render() {
@@ -115,11 +126,12 @@ class PartnerDialog extends Component {
 
                         <Grid item md={6}>
                             <SelectForm fieldName="partner_type" label={labels.partnerType} values={partnerTypeOptions}
-                                        optional/>
+                                        onChange={this.handleChange} optional/>
                         </Grid>
 
                         <Grid item md={6}>
-                            <SelectForm fieldName="cso_type" label={labels.cso_type} values={csoTypeOptions} selectFieldProps={{disabled: true}} optional/>
+                            <SelectForm fieldName="cso_type" label={labels.cso_type} values={csoTypeOptions}
+                                        selectFieldProps={{disabled: !this.state.csoSelected}} optional/>
                         </Grid>
 
                         <Grid item md={6}>

--- a/react/id_management_frontend/src/components/Partners/PartnerDialog.jsx
+++ b/react/id_management_frontend/src/components/Partners/PartnerDialog.jsx
@@ -4,13 +4,14 @@ import DialogActions from "../common/DialogActions";
 import TextFieldForm from "../form/TextFieldForm";
 import {Grid, Button} from "@material-ui/core";
 import {email, phoneNumber} from "../../helpers/validation";
-import {reduxForm} from 'redux-form';
+import {reduxForm, change} from 'redux-form';
 import {api} from "../../infrastructure/api";
 import {getLabels} from "../../labels";
 import ButtonSubmit from "../common/ButtonSubmit";
 import SelectForm from "../form/SelectForm";
 import SearchSelectForm from "../form/SearchSelectForm";
 import {connect} from "react-redux";
+import {bindActionCreators} from "redux";
 import withProps from "../hoc/withProps";
 import {clusterOptions, partnerTypeOptions} from "../../helpers/props";
 import partnerLabels from "./partnerLabels";
@@ -64,6 +65,7 @@ class PartnerDialog extends Component {
             this.setState({ csoSelected: true });
         } else {
             this.setState({ csoSelected: false });
+            this.props.dispatch(change('addPartnerForm', 'cso_type', ''));
         }
     }
 
@@ -205,6 +207,10 @@ const title = {
     edit: "Edit Partner"
 };
 
+const mapDispatchToProps = (dispatch) => {
+    return bindActionCreators({change}, dispatch);
+}
+
 const mapStateToProps = (state, ownProps) => {
     const {partner} = ownProps;
 
@@ -232,4 +238,4 @@ const mapStateToProps = (state, ownProps) => {
 export default withProps(
     clusterOptions,
     partnerTypeOptions
-)(connect(mapStateToProps)(reduxForm({form: "addPartnerForm", enableReinitialize: true})(PartnerDialog)));
+)(connect(mapStateToProps, mapDispatchToProps)(reduxForm({form: "addPartnerForm", enableReinitialize: true})(PartnerDialog)));

--- a/react/id_management_frontend/src/components/Partners/PartnerDialog.jsx
+++ b/react/id_management_frontend/src/components/Partners/PartnerDialog.jsx
@@ -61,11 +61,11 @@ class PartnerDialog extends Component {
     }
 
     handleChange(e) {
-        if (e.target.value === 'CSO') {
+        if (e.target.value === "CSO") {
             this.setState({ csoSelected: true });
         } else {
             this.setState({ csoSelected: false });
-            this.props.dispatch(change('addPartnerForm', 'cso_type', ''));
+            this.props.dispatch(change("addPartnerForm", "cso_type", ""));
         }
     }
 

--- a/react/id_management_frontend/src/components/Partners/PartnerDialog.jsx
+++ b/react/id_management_frontend/src/components/Partners/PartnerDialog.jsx
@@ -119,7 +119,7 @@ class PartnerDialog extends Component {
                         </Grid>
 
                         <Grid item md={6}>
-                            <SelectForm fieldName="cso_type" label={labels.cso_type} values={csoTypeOptions} optional/>
+                            <SelectForm fieldName="cso_type" label={labels.cso_type} values={csoTypeOptions} selectFieldProps={{disabled: true}} optional/>
                         </Grid>
 
                         <Grid item md={6}>

--- a/react/id_management_frontend/src/components/form/SelectForm.jsx
+++ b/react/id_management_frontend/src/components/form/SelectForm.jsx
@@ -38,6 +38,7 @@ class SelectForm extends Component {
             sections,
             multiple,
             textFieldProps,
+            onChange
         } = this.props;
 
         return (
@@ -67,6 +68,7 @@ class SelectForm extends Component {
                         fullWidth
                         infoText={infoText}
                         values={sections ? R.reduce((current, [_, nextValues]) => R.concat(current, nextValues), [], values) : values}
+                        onChange={onChange}
                     >
                         {renderSelectOptions(fieldName, values, sections)}
                     </Field>


### PR DESCRIPTION
# This PR completes [ch16984].

### Feature list
* _Describe the list of features from React_
  - Added logic to enable/disable `cso_type` field depending on whether or not "CSO" was selected for the `partner_type` dropdown
  - Added new state boolean to keep track of whether or not CSO field should be enabled or disabled
  - Added logic to reset the boolean back to false upon closing the modal

### Screenshots:
![cso_field](https://user-images.githubusercontent.com/27440940/70090388-e7863500-15ce-11ea-889c-c9b644600213.gif)
