### PR TITLE
[ch16896] Percentage indicator display bug fix

### DIFF
--- a/polymer/src/behaviors/utils.html
+++ b/polymer/src/behaviors/utils.html
@@ -125,7 +125,7 @@
 
       _toPercentage: function (value) {
         return value == null /* undefinded & null */ ? // jshint ignore:line
-            value : Math.floor(value * 100) + '%';
+            value : Math.floor(value * 100) / 100 + '%';
       },
 
       _formatIndicatorValue: function(indicatorType, value, percentize) {

--- a/polymer/src/behaviors/utils.html
+++ b/polymer/src/behaviors/utils.html
@@ -125,7 +125,11 @@
 
       _toPercentage: function (value) {
         return value == null /* undefinded & null */ ? // jshint ignore:line
-            value : Math.floor(value * 100) / 100 + '%';
+            value : Math.floor(value * 100) + '%';
+      },
+
+      _toPercentageRounded: function (value) {
+        return value == null ? value : Math.floor(value * 100) / 100 + '%';
       },
 
       _formatIndicatorValue: function(indicatorType, value, percentize) {

--- a/polymer/src/elements/cluster-reporting/analysis/indicator-details.html
+++ b/polymer/src/elements/cluster-reporting/analysis/indicator-details.html
@@ -134,7 +134,7 @@
                     is="dom-if"
                     if="[[!_equals(data.display_type, 'number')]]"
                     restamp="true">
-                  <span>[[_toPercentage(data.total.c)]]</span>
+                  <span>[[_toPercentageRounded(data.total.c)]]</span>
                 </template>
               </strong>
             </dd>
@@ -155,7 +155,7 @@
                   is="dom-if"
                   if="[[!_equals(data.display_type, 'number')]]"
                   restamp="true">
-                <span>[[_toPercentage(data.baseline.c)]]</span>
+                <span>[[_toPercentageRounded(data.baseline.c)]]</span>
               </template>
             </dd>
           </dl>
@@ -172,7 +172,7 @@
                   is="dom-if"
                   if="[[!_equals(data.display_type, 'number')]]"
                   restamp="true">
-                <span>[[_toPercentage(data.target.c)]]</span>
+                <span>[[_toPercentageRounded(data.target.c)]]</span>
               </template>
             </dd>
           </dl>
@@ -189,7 +189,7 @@
                   is="dom-if"
                   if="[[!_equals(data.display_type, 'number')]]"
                   restamp="true">
-                <span>[[_toPercentage(data.in_need.c)]]</span>
+                <span>[[_toPercentageRounded(data.in_need.c)]]</span>
               </template>
             </dd>
           </dl>


### PR DESCRIPTION
# This PR completes [ch16896].

### Feature list
* _Describe the list of features from Polymer_
  - Adjusted the `_toPercentage` method in `utils.html` to multiply and then divide by 100 in order to correctly return a percentage, rounded to the nearest hundredth.

### Screenshots:
![image](https://user-images.githubusercontent.com/27440940/70100478-b31e7300-15e6-11ea-8e3d-d83217c56314.png)
