### PR TITLE
[ch16998] Update budget label to have "(USD)" text

### DIFF
--- a/polymer/src/elements/cluster-reporting/creation-modal-project-details.html
+++ b/polymer/src/elements/cluster-reporting/creation-modal-project-details.html
@@ -64,7 +64,7 @@
               </labelled-item>
             </li>
             <li class="item">
-              <labelled-item label="[[localize('total_budget')]]">
+              <labelled-item label="[[localize('total_budget')]] (USD)">
                 <span class="value">
                   <etools-prp-number value="[[projectData.totalBudgetUSD]]"></etools-prp-number>
                 </span>

--- a/polymer/src/elements/cluster-reporting/planned-action/projects/creation-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/projects/creation-modal.html
@@ -445,7 +445,7 @@
                   <paper-input
                     class="item validate"
                     id="total_budget"
-                    label="[[localize('total_budget')]]"
+                    label="[[localize('total_budget')]] (USD)"
                     value="{{ data.total_budget }}"
                     type="number"
                     allowed-pattern="[+\-\d.]"

--- a/polymer/src/elements/cluster-reporting/project-details.html
+++ b/polymer/src/elements/cluster-reporting/project-details.html
@@ -109,7 +109,7 @@
               </labelled-item>
             </li>
             <li class="item">
-              <labelled-item label="[[localize('total_budget')]]">
+              <labelled-item label="[[localize('total_budget')]] (USD)">
                 <span class="value">
                   <etools-prp-number value="[[projectData.total_budget]]"></etools-prp-number>
                 </span>

--- a/polymer/src/elements/cluster-reporting/project-list-table.html
+++ b/polymer/src/elements/cluster-reporting/project-list-table.html
@@ -14,6 +14,7 @@
 <link rel="import" href="../../behaviors/routing.html">
 <link rel="import" href="../../behaviors/utils.html">
 <link rel="import" href="../etools-prp-ajax.html">
+<link rel="import" href="../etools-prp-number.html">
 <link rel="import" href="../project-status.html">
 <link rel="import" href="../page-body.html">
 <link rel="import" href="../list-placeholder.html">
@@ -146,8 +147,8 @@
                 <div class="table-cell table-cell--text">
                   <span class="label">[[localize('start_date')]]</span>
                   [[project.start_date]]
-                  <span class="label">[[localize('total_budget')]]</span>
-                  [[project.total_budget]]
+                  <span class="label">[[localize('total_budget')]] (USD)</span>
+                  <etools-prp-number value="[[project.total_budget]]"></etools-prp-number>
                 </div>
                 <div class="table-cell table-cell--text">
                   <span class="label">[[localize('end_date')]]</span>


### PR DESCRIPTION
# This PR completes [ch16998].

### Feature list
* _Describe the list of features from Polymer_
  - Updated `paper-input` label in `creation-modal.html` component (the Add Project/Edit Project modals) with `"(USD)"` text at the end after the localized text
  - Added `"(USD)"` text to the `project-details.html` component (the Project Details page), the `project-list-table.html` component (the expanding dropdown on the project list), and the `creation-modal-project-details.html` component (for when a user selects the "From OCHA" option and gets a project detail view in the modal
  - Wrapped `total_budget` value in the `project-list-table.html` component with the `etools-prp-number.html` component in order to render 0 correctly when value is null

### Screenshots:
**Add Project modal**:
![image](https://user-images.githubusercontent.com/27440940/70464218-4fc39380-1a73-11ea-9091-0eddf5513580.png)

**Edit Project modal**:
![image](https://user-images.githubusercontent.com/27440940/70464250-64079080-1a73-11ea-937b-c23b5e802815.png)

**Project list table expanded view**:
![image](https://user-images.githubusercontent.com/27440940/70467471-22c6af00-1a7a-11ea-925b-0051b5794567.png)

**Add Project from OCHA**:
![image](https://user-images.githubusercontent.com/27440940/70467303-c82d5300-1a79-11ea-82ac-eab80566cd0f.png)
