### PR TITLE
[ch16946] Add project context dropdown field for adding a custom activity indicator

### DIFF
--- a/polymer/src/elements/cluster-reporting/indicator-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-modal.html
@@ -360,6 +360,26 @@
                       </paper-input>
                     </div>
 
+                    <template
+                    is="dom-if"
+                    if="[[_equals(modalTitle, 'Add Activity Indicator')]]"
+                    restamp="true">
+                      <div class="item full-width">
+                        <etools-single-selection-menu
+                          class="item validate pair"
+                          label="[[localize('project_context')]]"
+                          options="[[activityData.projects]]"
+                          option-value="context_id"
+                          option-label="project_name"
+                          selected="{{data.project_context_id}}"
+                          on-iron-activate="_validate"
+                          trigger-value-change-event
+                          hide-search
+                          required>
+                        </etools-single-selection-menu>
+                      </div>
+                    </template>
+
                     <div class="item full-width">
                       <div class="app-grid double">
                         <etools-single-selection-menu


### PR DESCRIPTION
# This PR completes [ch16946].

##### Feature list
* _Describe the list of features from Polymer_
  - Added the missing `project_context_id` dropdown field for the custom activity indicator modal form in order to successfully create a custom activity indicator

### Screenshots:
<img width="1246" alt="Screen Shot 2019-12-09 at 3 29 26 PM" src="https://user-images.githubusercontent.com/27440940/70482170-a0e67e00-1a99-11ea-95e0-fbc9a5a8f533.png">

<img width="1636" alt="Screen Shot 2019-12-09 at 3 30 26 PM" src="https://user-images.githubusercontent.com/27440940/70482179-a80d8c00-1a99-11ea-92c1-4039a76fd591.png">