### PR TITLE
[ch16924] Filter out partner activities that don't belong to the current project's partner

### DIFF
--- a/polymer/src/elements/cluster-reporting/planned-action/activities/add-existing-activity-from-project-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/activities/add-existing-activity-from-project-modal.html
@@ -494,7 +494,12 @@
                   return element.project_id === parseInt(self.projectData.id);
                 }) === undefined;
               });
-              self.set('partnerActivities', filteredActivities);
+              console.log('filteredActivities', filteredActivities);
+              var currentPartnerActivities = filteredActivities.filter(function (activity) {
+                return activity.partner.id === self.currentPartnerId;
+              });
+              self.set('partnerActivities', currentPartnerActivities);
+              console.log('self.partnerActivities', self.partnerActivities);
             })
             .catch(function (err) { // jshint ignore:line
               // TODO: error handling

--- a/polymer/src/elements/cluster-reporting/planned-action/activities/add-existing-activity-from-project-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/activities/add-existing-activity-from-project-modal.html
@@ -396,6 +396,10 @@
           computed: '_computeObjectivesUrl(responsePlanId)',
         },
 
+        currentPartnerId: {
+          type: Number
+        },
+
         partner: {
           type: Object,
           computed: '_computePartner(storePartner, selectedPartner)'
@@ -445,6 +449,7 @@
         this.set('activities', []);
         this.set('objectives', []);
         this.set('errors', {});
+        this.set('currentPartnerId', this.projectData.partner_id);
       },
 
       _onOpenedChanged: function (opened) {

--- a/polymer/src/elements/cluster-reporting/planned-action/activities/add-existing-activity-from-project-modal.html
+++ b/polymer/src/elements/cluster-reporting/planned-action/activities/add-existing-activity-from-project-modal.html
@@ -494,12 +494,10 @@
                   return element.project_id === parseInt(self.projectData.id);
                 }) === undefined;
               });
-              console.log('filteredActivities', filteredActivities);
               var currentPartnerActivities = filteredActivities.filter(function (activity) {
                 return activity.partner.id === self.currentPartnerId;
               });
               self.set('partnerActivities', currentPartnerActivities);
-              console.log('self.partnerActivities', self.partnerActivities);
             })
             .catch(function (err) { // jshint ignore:line
               // TODO: error handling


### PR DESCRIPTION
# This PR completes [ch16924].

### Feature list
* _Describe the list of features from Polymer_
  - Added `currentPartnerId` property to `add-existing-activity-from-project-modal.html` component
  - Used the `currentPartnerId` value to return only the `filteredActivities` that belong to the current project's partner

### Screenshots:
![current_partner_activities](https://user-images.githubusercontent.com/27440940/70574531-2d0baa80-1b59-11ea-9af2-d20b0e6baa58.gif)
