### PR TITLE
[ch17011] Allow IMO users to edit partner activity indicators

### DIFF
--- a/polymer/src/elements/cluster-reporting/indicator-editing-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-editing-modal.html
@@ -534,8 +534,13 @@
       },
 
       _computeCanEditDetails: function (permissions, data, isPAI) {
-        console.log('this.currentUserRoles', this.currentUserRoles);
-        console.log('this.data', this.data);
+        var isUserImo = this.currentUserRoles.find(function (role) {
+          return role.role === 'CLUSTER_IMO';
+        });
+        if (isUserImo !== undefined) {
+          return true;
+        }
+
         return (permissions.createClusterEntities && !isPAI) ||
             (permissions.onlyEditOwnIndicatorDetails && !data.parent_indicator);
       },

--- a/polymer/src/elements/cluster-reporting/indicator-editing-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-editing-modal.html
@@ -486,6 +486,11 @@
           },
           computed: '_computeMinDate(data.start_date_of_reporting_period)',
         },
+        
+        currentUserRoles: {
+          type: Array,
+          statePath: 'userProfile.profile.prp_roles'
+        }
       },
 
       observers: [
@@ -529,6 +534,8 @@
       },
 
       _computeCanEditDetails: function (permissions, data, isPAI) {
+        console.log('this.currentUserRoles', this.currentUserRoles);
+        console.log('this.data', this.data);
         return (permissions.createClusterEntities && !isPAI) ||
             (permissions.onlyEditOwnIndicatorDetails && !data.parent_indicator);
       },

--- a/polymer/src/elements/cluster-reporting/indicator-locations-widget.html
+++ b/polymer/src/elements/cluster-reporting/indicator-locations-widget.html
@@ -388,9 +388,14 @@
             computed: '_computeAjaxData(maxAdminLevel)',
           },
 
+          currentUserRoles: {
+            type: Array,
+            statePath: 'userProfile.profile.prp_roles'
+          },
+
           canEditDetails: {
             type: Boolean,
-            computed: '_computeCanEditDetails(editing, parentIndicatorId, isPai, permissions)',
+            computed: '_computeCanEditDetails(currentUserRoles, editing, parentIndicatorId, isPai, permissions)',
           },
 
           canMessageIMO: {
@@ -476,7 +481,14 @@
               });
         },
 
-        _computeCanEditDetails: function (editing, parentIndicatorId, isPAI, permissions) {
+        _computeCanEditDetails: function (currentUserRoles, editing, parentIndicatorId, isPAI, permissions) {
+          var isUserImo = currentUserRoles.find(function (role) {
+            return role.role === 'CLUSTER_IMO';
+          });
+          if (isUserImo !== undefined) {
+            return true;
+          }
+
           return !editing ||
               (permissions.createClusterEntities && !isPAI) ||
               (permissions.onlyEditOwnIndicatorDetails && !parentIndicatorId);


### PR DESCRIPTION
# This PR completes [ch17011].

### Feature list
* _Describe the list of features from Polymer_
  - Added `currentUserRoles` property to both the `indicator-editing-modal.html` and `indicator-locations-widget.html` components
  - Added check inside the `_computeCanEditDetails` method to see if user's roles includes a `CLUSTER_IMO` role, and if so, to return true and allow the modal (and the baseline values for the locations) to be editable

### Screenshots:
![image](https://user-images.githubusercontent.com/27440940/70584908-6f43e480-1b77-11ea-9d3f-4645f9af6c26.png)
