### PR TITLE
[ch17026] Render Add Activity Indicator button correctly

### DIFF
--- a/polymer/src/elements/cluster-reporting/response-parameters/clusters/activities/indicators.html
+++ b/polymer/src/elements/cluster-reporting/response-parameters/clusters/activities/indicators.html
@@ -123,8 +123,13 @@
 
         canAddIndicator: {
           type: Boolean,
-          computed: '_computeCanAddIndicator(permissions, clusterId)',
+          computed: '_computeCanAddIndicator(currentUserRoles, permissions, clusterId)',
         },
+
+        currentUserRoles: {
+          type: Array,
+          statePath: 'userProfile.profile.prp_roles'
+        }
       },
 
       listeners: {
@@ -170,7 +175,14 @@
           });
       },
 
-      _computeCanAddIndicator: function (permissions, clusterId) {
+      _computeCanAddIndicator: function (currentUserRoles, permissions, clusterId) {
+        var isUserImo = currentUserRoles.find(function (role) {
+          return role.role === 'CLUSTER_IMO';
+        });
+        if (isUserImo !== undefined) {
+          return true;
+        }
+
         return permissions.createClusterEntities &&
             permissions.createClusterEntitiesForCluster(clusterId);
       },


### PR DESCRIPTION
# This PR completes [ch17026].

### Feature list
* _Describe the list of features from Polymer_
  - Added `currentUserRoles` property and conditional to check if IMO-type role exists for the current user, and if so, immediately render the "Add Activity Indicator" button