### PR TITLE
[ch16906] Change validation for percentage/ratio indicator types

### DIFF
--- a/polymer/src/elements/cluster-reporting/indicator-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-modal.html
@@ -1466,17 +1466,6 @@
                 'Location ' + location.title + ' has a greater baseline than its indicator-level baseline'
               );
             }
-            if (location.target.v > data.target.v) {
-              invalidLocations.push(
-                'Location ' + location.title + ' has a greater target than its indicator-level target'
-              );
-            }
-
-            if (location.in_need !== undefined && location.target.v > location.in_need.v) {
-              invalidLocations.push(
-                'Location ' + location.title + ' has a target greater than its in need'
-              );
-            }
 
             arr[idx] = location;
           });
@@ -1577,17 +1566,6 @@
             if (location.baseline.c > data.baseline.c) {
               invalidLocations.push(
                 'Location ' + location.title + ' has a greater baseline than its indicator-level baseline'
-              );
-            }
-            if (location.target.c > data.target.c) {
-              invalidLocations.push(
-                'Location ' + location.title + ' has a greater target than its indicator-level target'
-              );
-            }
-
-            if (location.in_need !== undefined && location.target.c > location.in_need.c) {
-              invalidLocations.push(
-                'Location ' + location.title + ' has a target greater than its in need'
               );
             }
 

--- a/polymer/src/elements/cluster-reporting/indicator-modal.html
+++ b/polymer/src/elements/cluster-reporting/indicator-modal.html
@@ -1467,6 +1467,12 @@
               );
             }
 
+            if (location.in_need !== undefined && location.target.v > location.in_need.v) {
+              invalidLocations.push(
+                'Location ' + location.title + ' has a target greater than its in need'
+              );
+            }
+
             arr[idx] = location;
           });
         } else if (data.blueprint.display_type === 'number') {
@@ -1566,6 +1572,12 @@
             if (location.baseline.c > data.baseline.c) {
               invalidLocations.push(
                 'Location ' + location.title + ' has a greater baseline than its indicator-level baseline'
+              );
+            }
+
+            if (location.in_need !== undefined && location.target.c > location.in_need.c) {
+              invalidLocations.push(
+                'Location ' + location.title + ' has a target greater than its in need'
               );
             }
 


### PR DESCRIPTION
# This PR completes [ch16906].

### Feature list
* _Describe the list of features from Polymer_
  - Removed the conditionals that would throw an error if a location's target value was greater than  the overall target value, for both percentage and ratio indicator types

### Screenshots:
![percentage_validation](https://user-images.githubusercontent.com/27440940/71028292-dc98cd80-20c1-11ea-9607-64dad3407279.gif)
