### PR TITLE
[ch20720] Cluster-PRP: When performing "Add New Project Activity", 'A…

### DIFF
--- a/polymer_3/src_ts/elements/cluster-reporting/planned-action/activities/add-activity-from-project-modal.ts
+++ b/polymer_3/src_ts/elements/cluster-reporting/planned-action/activities/add-activity-from-project-modal.ts
@@ -657,10 +657,13 @@ class AddActivityFromProjectModal extends LocalizeMixin(UtilsMixin(ModalMixin(Re
         return (self.$.partnerActivities as EtoolsPrpAjaxEl).thunk()();
       })
       .then((res: any) => {
+        // logic below will exclude activities already adopted for the current Project
+        const currentProjId = Number(self.projectData.id);
         const adoptedClusterActivities = new Set();
         res.data.results.forEach(function(item: any) {
           if (item.cluster_activity !== null) {
-            adoptedClusterActivities.add(item.cluster_activity.id);
+            if ((item.projects || []).filter((proj: GenericObject) => Number(proj.project_id) === currentProjId).length > 0)
+              adoptedClusterActivities.add(item.cluster_activity.id);
           }
         });
 


### PR DESCRIPTION
[ch20720] Cluster-PRP: When performing "Add New Project Activity", 'Activity' dropdown excludes Cluster Activities adopted for ANOTHER Project. It should only exclude Activities adopted for the SAME Project.