### PR TITLE
[ch20792] Clicking on the report header link redirects user to Overview (not showing PD details)

### DIFF
--- a/polymer_3/src_ts/pages/app/ip-reporting/pd/pd-report.ts
+++ b/polymer_3/src_ts/pages/app/ip-reporting/pd/pd-report.ts
@@ -143,11 +143,13 @@ class PageIpReportingPdReport extends LocalizeMixin(RoutingMixin(
         report="[[currentReport]]">
       </pd-reports-report-title>
 
-      <a
-          href="#"
+      <paper-button
+          class="btn-primary"
           slot="in-title"
-          class="pd-details-link"
-          on-tap="_showPdDetails">[[currentReport.programme_document.reference_number]]</a>
+          role="button"
+          on-tap="_showPdDetails">
+        [[currentReport.programme_document.reference_number]]
+      </paper-button>
 
       <template
           is="dom-if"


### PR DESCRIPTION
[ch20792] Clicking on the report header link redirects user to Overview (not showing PD details)