### PR TITLE
Incomplete filter

### DIFF
--- a/django_api/django_api/apps/unicef/serializers.py
+++ b/django_api/django_api/apps/unicef/serializers.py
@@ -402,7 +402,7 @@ class ProgressReportSerializer(ProgressReportSimpleSerializer):
         if self.location_id and self.llo_id is not None:
             queryset = queryset.filter(reportable__locations__id=self.location_id)
 
-        if self.show_incomplete_only == Boolean.TRUE:
+        if self.show_incomplete_only in [1, "1", "true", "True", True]:
             queryset = filter(
                 lambda x: not x.is_complete,
                 queryset

--- a/django_api/django_api/apps/unicef/tests/test_views.py
+++ b/django_api/django_api/apps/unicef/tests/test_views.py
@@ -818,6 +818,31 @@ class TestProgressReportAPIView(BaseAPITestCase):
         self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(len(response.data['results']), len(pr_queryset))
 
+    def test_detail_api_filter_incomplete(self):
+        progress_report = self.pd.progress_reports.first()
+        ir_qs = IndicatorReport.objects.filter(
+            progress_report=progress_report,
+        )
+        url = reverse(
+            'progress-reports-details',
+            args=[self.workspace.pk, progress_report.pk],
+        )
+        response = self.client.get(url, format='json')
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEquals(
+            len(response.data['indicator_reports']),
+            ir_qs.count(),
+        )
+
+        ir_qs = ir_qs.filter(submission_date__isnull=True)
+        url += '?incomplete=true'
+        response = self.client.get(url, format='json')
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEquals(
+            len(response.data['indicator_reports']),
+            ir_qs.count(),
+        )
+
     @patch("django_api.apps.utils.emails.EmailTemplate.objects.update_or_create")
     @patch.object(Notification, "full_clean", return_value=None)
     @patch.object(Notification, "send_notification", return_value=None)

--- a/django_api/django_api/apps/unicef/urls.py
+++ b/django_api/django_api/apps/unicef/urls.py
@@ -55,7 +55,7 @@ urlpatterns = [
         name="progress-reports-details"),
     url(r'^(?P<workspace_id>\d+)/progress-reports/(?P<pk>\d+)/update/$',
         ProgressReportDetailsUpdateAPIView.as_view(),
-        name="progress-reports-details"),
+        name="progress-reports-details-update"),
     url(r'^(?P<workspace_id>\d+)/progress-reports/(?P<pk>\d+)/annex-C-export-PDF/$',
         ProgressReportAnnexCPDFView.as_view(),
         name="progress-reports-pdf"),


### PR DESCRIPTION
[ch20968]

The incomplete var was checked against the constant `Boolean.True` which is set to the value `1`
But the value being passed in was `true`, this constant is used in a number of places, so doubt that this endpoint is the only one having an issue. Just fixed this endpoint for now.