### PR TITLE
Add filtering in exports at indicator reports level

### DIFF
--- a/django_api/django_api/apps/unicef/exports/annex_c_excel.py
+++ b/django_api/django_api/apps/unicef/exports/annex_c_excel.py
@@ -74,6 +74,7 @@ class ProgressReportsXLSXExporter:
             progress_reports,
             include_disaggregations=None,
             export_to_single_sheet=None,
+            request=None,
     ):
         self.progress_reports = progress_reports or list()
         filename = ''.join([
@@ -83,6 +84,7 @@ class ProgressReportsXLSXExporter:
         self.display_name = '[{:%a %-d %b %-H-%M-%S %Y}] Progress Report(s) Summary.xlsx'.format(
             timezone.now()
         )
+        self.request = request
 
         self.workbook = Workbook()
 

--- a/django_api/django_api/apps/unicef/exports/programme_documents.py
+++ b/django_api/django_api/apps/unicef/exports/programme_documents.py
@@ -24,7 +24,7 @@ def calc_cash_transfer_percentage(pd):
 
 class ProgrammeDocumentsXLSXExporter:
 
-    def __init__(self, programme_documents):
+    def __init__(self, programme_documents, request=None):
         self.programme_documents = programme_documents
         filename = hashlib.sha256(';'.join([str(p.pk) for p in programme_documents]).encode('utf-8')).hexdigest()
         self.file_path = os.path.join(tempfile.gettempdir(), filename + '.xlsx')
@@ -134,7 +134,7 @@ class ProgrammeDocumentsPDFExporter:
 
     template_name = 'programme_documents_pdf_export.html'
 
-    def __init__(self, programme_documents):
+    def __init__(self, programme_documents, request=None):
         self.programme_documents = programme_documents
         self.file_name = '[{:%a %-d %b %-H-%M-%S %Y}] {} Programme Document(s) Summary.pdf'.format(
             timezone.now(), programme_documents.count()

--- a/django_api/django_api/apps/utils/mixins.py
+++ b/django_api/django_api/apps/utils/mixins.py
@@ -77,7 +77,8 @@ class ListExportMixin(object):
         exporter_class = self.get_exporter_class()
         if exporter_class:
             return exporter_class(
-                self.filter_queryset(self.get_queryset())
+                self.filter_queryset(self.get_queryset()),
+                request=request,
             ).get_as_response()
 
         return super(ListExportMixin, self).get(request, *args, **kwargs)


### PR DESCRIPTION
[ch7973]

Filtering at the view level returns Reportables that match the filtering, but when we export the data all indicator reports are pulled for each of the Reportables, and so we're losing the filtering at this point.