### PR TITLE
Update notification link to unicef staff to point to pmp, not prp

### DIFF
--- a/django_api/django_api/apps/unicef/models.py
+++ b/django_api/django_api/apps/unicef/models.py
@@ -519,6 +519,11 @@ def send_notification_on_status_change(sender, instance, **kwargs):
                 content_subtype='html',
             )
 
+        # update pr url link to point to pmp, not prp
+        part_pr_url = f'/pmp/reportings/{instance.id}/progress'
+        pr_url = urljoin(settings.FRONTEND_PMP_HOST, part_pr_url)
+        template_data["pr_url"] = pr_url
+
         for person in pd.unicef_focal_point.all():
             template_data['person'] = person
             to_email_list = [person.email]

--- a/django_api/django_api/settings/base.py
+++ b/django_api/django_api/settings/base.py
@@ -56,6 +56,11 @@ FRONTEND_HOST = os.getenv(
     'PRP_FRONTEND_HOST',
     os.getenv('DJANGO_ALLOWED_HOST', 'http://localhost:8081')
 )
+FRONTEND_PMP_HOST = os.getenv(
+    'PRP_FRONTEND_PMP_HOST',
+    os.getenv('DJANGO_ALLOWED_HOST', 'http://localhost:8081')
+)
+
 
 EMAIL_BACKEND = 'unicef_notification.backends.EmailBackend'
 


### PR DESCRIPTION
[ch22076]

`PRP_FRONTEND_PMP_HOST` environment var needs to be set to relevant environments