### PR TITLE
263988 still displays removed

### DIFF
--- a/django_api/etools_prp/apps/unicef/sync/update_create_reportable_location_goal.py
+++ b/django_api/etools_prp/apps/unicef/sync/update_create_reportable_location_goal.py
@@ -31,3 +31,5 @@ def update_create_reportable_location_goals(reportable: Reportable, locations: l
     ReportableLocationGoal.objects.bulk_create(reportable_location_goals)
 
     ReportableLocationGoal.objects.filter(reportable=reportable, location__in=locations).update(is_active=True)
+
+    ReportableLocationGoal.objects.filter(reportable=reportable).exclude(location__in=locations).update(is_active=False)

--- a/django_api/etools_prp/apps/unicef/tests/test_sync_update_create_reportable_location_goal.py
+++ b/django_api/etools_prp/apps/unicef/tests/test_sync_update_create_reportable_location_goal.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
+from django.contrib.contenttypes.models import ContentType
 
 from etools_prp.apps.core.tests import factories
-from etools_prp.apps.indicator.models import ReportableLocationGoal
+from etools_prp.apps.indicator.models import ReportableLocationGoal, IndicatorBlueprint, Reportable
 from etools_prp.apps.unicef.sync.update_create_reportable_location_goal import (
     update_create_reportable_location_goals,
 )
@@ -10,7 +11,28 @@ from etools_prp.apps.unicef.sync.update_create_reportable_location_goal import (
 class TestUpdateCreateReportableLocationGoals(TestCase):
 
     def setUp(self):
-        self.reportable = factories.QuantityReportableToLowerLevelOutputFactory()
+        
+        # creating pd, llos, etc.
+        self.pd = factories.ProgrammeDocumentFactory()
+        self.cp_output = factories.PDResultLinkFactory(programme_document=self.pd)
+        self.llo = factories.LowerLevelOutputFactory(cp_output=self.cp_output)
+        self.blueprint = IndicatorBlueprint.objects.create(
+            title="Test Indicator",
+            unit=IndicatorBlueprint.NUMBER,
+            calculation_formula_across_locations=IndicatorBlueprint.SUM,
+            calculation_formula_across_periods=IndicatorBlueprint.SUM,
+            display_type=IndicatorBlueprint.NUMBER,
+        )
+        llo_ct = ContentType.objects.get_for_model(type(self.llo))
+
+        # creating reportable
+        self.reportable = Reportable.objects.create(
+            content_type=llo_ct,
+            object_id=self.llo.id,
+            blueprint=self.blueprint,
+        )
+
+        # creating locations
         self.loc1 = factories.LocationFactory()
         self.loc2 = factories.LocationFactory()
 
@@ -24,6 +46,8 @@ class TestUpdateCreateReportableLocationGoals(TestCase):
         )
 
     def test_deactivates_removed_locations(self):
+        
+        # asserting that locations are active initially
         rlg1 = ReportableLocationGoal.objects.get(
             reportable=self.reportable, location=self.loc1
         )
@@ -33,8 +57,10 @@ class TestUpdateCreateReportableLocationGoals(TestCase):
         self.assertTrue(rlg1.is_active)
         self.assertTrue(rlg2.is_active)
 
+        # this is what the process_pd_item script would run 
         update_create_reportable_location_goals(self.reportable, [self.loc1])
 
+        # asserting the locations are active
         rlg1.refresh_from_db()
         rlg2.refresh_from_db()
         self.assertTrue(rlg1.is_active)
@@ -46,15 +72,21 @@ class TestUpdateCreateReportableLocationGoals(TestCase):
         )
 
     def test_reactivate_and_deactivate_mixed_state(self):
+        # setting first location to inactive 
+        # (what happens when a location is removed from the pd)
         ReportableLocationGoal.objects.filter(
             reportable=self.reportable, location=self.loc1
         ).update(is_active=False)
+
+        # setting second location to active
         ReportableLocationGoal.objects.filter(
             reportable=self.reportable, location=self.loc2
         ).update(is_active=True)
 
+        # running script
         update_create_reportable_location_goals(self.reportable, [self.loc1])
 
+        # location 2 is now effectively inactive
         rlg1 = ReportableLocationGoal.objects.get(
             reportable=self.reportable, location=self.loc1
         )

--- a/django_api/etools_prp/apps/unicef/tests/test_sync_update_create_reportable_location_goal.py
+++ b/django_api/etools_prp/apps/unicef/tests/test_sync_update_create_reportable_location_goal.py
@@ -1,17 +1,14 @@
-from django.test import TestCase
 from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
 
 from etools_prp.apps.core.tests import factories
-from etools_prp.apps.indicator.models import ReportableLocationGoal, IndicatorBlueprint, Reportable
-from etools_prp.apps.unicef.sync.update_create_reportable_location_goal import (
-    update_create_reportable_location_goals,
-)
+from etools_prp.apps.indicator.models import IndicatorBlueprint, Reportable, ReportableLocationGoal
+from etools_prp.apps.unicef.sync.update_create_reportable_location_goal import update_create_reportable_location_goals
 
 
 class TestUpdateCreateReportableLocationGoals(TestCase):
 
     def setUp(self):
-        
         # creating pd, llos, etc.
         self.pd = factories.ProgrammeDocumentFactory()
         self.cp_output = factories.PDResultLinkFactory(programme_document=self.pd)
@@ -46,7 +43,6 @@ class TestUpdateCreateReportableLocationGoals(TestCase):
         )
 
     def test_deactivates_removed_locations(self):
-        
         # asserting that locations are active initially
         rlg1 = ReportableLocationGoal.objects.get(
             reportable=self.reportable, location=self.loc1
@@ -57,7 +53,7 @@ class TestUpdateCreateReportableLocationGoals(TestCase):
         self.assertTrue(rlg1.is_active)
         self.assertTrue(rlg2.is_active)
 
-        # this is what the process_pd_item script would run 
+        # this is what the process_pd_item script would run
         update_create_reportable_location_goals(self.reportable, [self.loc1])
 
         # asserting the locations are active
@@ -72,7 +68,7 @@ class TestUpdateCreateReportableLocationGoals(TestCase):
         )
 
     def test_reactivate_and_deactivate_mixed_state(self):
-        # setting first location to inactive 
+        # setting first location to inactive
         # (what happens when a location is removed from the pd)
         ReportableLocationGoal.objects.filter(
             reportable=self.reportable, location=self.loc1
@@ -95,5 +91,3 @@ class TestUpdateCreateReportableLocationGoals(TestCase):
         )
         self.assertTrue(rlg1.is_active)
         self.assertFalse(rlg2.is_active)
-
-

--- a/django_api/etools_prp/apps/unicef/tests/test_sync_update_create_reportable_location_goal.py
+++ b/django_api/etools_prp/apps/unicef/tests/test_sync_update_create_reportable_location_goal.py
@@ -1,0 +1,67 @@
+from django.test import TestCase
+
+from etools_prp.apps.core.tests import factories
+from etools_prp.apps.indicator.models import ReportableLocationGoal
+from etools_prp.apps.unicef.sync.update_create_reportable_location_goal import (
+    update_create_reportable_location_goals,
+)
+
+
+class TestUpdateCreateReportableLocationGoals(TestCase):
+
+    def setUp(self):
+        self.reportable = factories.QuantityReportableToLowerLevelOutputFactory()
+        self.loc1 = factories.LocationFactory()
+        self.loc2 = factories.LocationFactory()
+
+        factories.LocationWithReportableLocationGoalFactory(
+            location=self.loc1,
+            reportable=self.reportable,
+        )
+        factories.LocationWithReportableLocationGoalFactory(
+            location=self.loc2,
+            reportable=self.reportable,
+        )
+
+    def test_deactivates_removed_locations(self):
+        rlg1 = ReportableLocationGoal.objects.get(
+            reportable=self.reportable, location=self.loc1
+        )
+        rlg2 = ReportableLocationGoal.objects.get(
+            reportable=self.reportable, location=self.loc2
+        )
+        self.assertTrue(rlg1.is_active)
+        self.assertTrue(rlg2.is_active)
+
+        update_create_reportable_location_goals(self.reportable, [self.loc1])
+
+        rlg1.refresh_from_db()
+        rlg2.refresh_from_db()
+        self.assertTrue(rlg1.is_active)
+        self.assertFalse(rlg2.is_active)
+
+        self.assertEqual(
+            ReportableLocationGoal.objects.filter(reportable=self.reportable).count(),
+            2,
+        )
+
+    def test_reactivate_and_deactivate_mixed_state(self):
+        ReportableLocationGoal.objects.filter(
+            reportable=self.reportable, location=self.loc1
+        ).update(is_active=False)
+        ReportableLocationGoal.objects.filter(
+            reportable=self.reportable, location=self.loc2
+        ).update(is_active=True)
+
+        update_create_reportable_location_goals(self.reportable, [self.loc1])
+
+        rlg1 = ReportableLocationGoal.objects.get(
+            reportable=self.reportable, location=self.loc1
+        )
+        rlg2 = ReportableLocationGoal.objects.get(
+            reportable=self.reportable, location=self.loc2
+        )
+        self.assertTrue(rlg1.is_active)
+        self.assertFalse(rlg2.is_active)
+
+


### PR DESCRIPTION
Here's what's going on : 

- Currently: PD sync creates missing ReportableLocationGoal links and sets is_active=True for locations in the payload, but it never deactivates links for locations removed from the PD (and the mass “reset inactive then reactivate” doesn’t always run for signed PDs).

- Why it fails: When a location is removed in eTools, its old link stays active in PRP because we don’t explicitly turn off links not present in the current payload, so the location still appears.

- What the fix does: After activating the provided set, we deactivate any links not in that set; this makes the operation idempotent and keeps PRP exactly aligned with the PD payload, without unintended reactivations.
