### PR TITLE
Optimised detail view for ProgramDocuments

### DIFF
--- a/django_api/etools_prp/apps/unicef/models.py
+++ b/django_api/etools_prp/apps/unicef/models.py
@@ -391,14 +391,14 @@ class ProgrammeDocument(TimeStampedExternalBusinessAreaModel):
 
     @property
     def locations_queryset(self):
-        return Location.objects.filter(
+        return Location.objects.only('id', 'name', 'admin_level', 'admin_level_name', 'p_code').filter(
             Q(
                 indicator_location_data__indicator_report__progress_report__programme_document=self
             ) | Q(
                 reportables__lower_level_outputs__cp_output__programme_document=self
             ),
             reportablelocationgoal__is_active=True,
-        ).distinct()
+        ).distinct('id')
 
 
 class ProgressReport(TimeStampedModel):

--- a/django_api/etools_prp/apps/unicef/models.py
+++ b/django_api/etools_prp/apps/unicef/models.py
@@ -391,14 +391,14 @@ class ProgrammeDocument(TimeStampedExternalBusinessAreaModel):
 
     @property
     def locations_queryset(self):
-        return Location.objects.only('id', 'name', 'admin_level', 'admin_level_name', 'p_code').filter(
+        return Location.objects.select_related(None).only('id', 'name', 'admin_level', 'admin_level_name', 'p_code').filter(
             Q(
                 indicator_location_data__indicator_report__progress_report__programme_document=self
             ) | Q(
                 reportables__lower_level_outputs__cp_output__programme_document=self
             ),
             reportablelocationgoal__is_active=True,
-        ).distinct('id')
+        ).order_by('id').distinct('id')
 
 
 class ProgressReport(TimeStampedModel):

--- a/django_api/etools_prp/apps/unicef/serializers.py
+++ b/django_api/etools_prp/apps/unicef/serializers.py
@@ -161,13 +161,22 @@ class ProgrammeDocumentSerializer(serializers.ModelSerializer):
         return obj.funds_received_to_date_currency
 
     def get_unicef_officers(self, obj):
-        return PersonSerializer(obj.unicef_officers.filter(active=True), read_only=True, many=True).data
+        officers = getattr(obj, 'prefetched_unicef_officers_active', None)
+        if officers is None:
+            officers = obj.unicef_officers.filter(active=True)
+        return PersonSerializer(officers, read_only=True, many=True).data
 
     def get_unicef_focal_point(self, obj):
-        return PersonSerializer(obj.unicef_focal_point.filter(active=True), read_only=True, many=True).data
+        focal = getattr(obj, 'prefetched_unicef_focal_point_active', None)
+        if focal is None:
+            focal = obj.unicef_focal_point.filter(active=True)
+        return PersonSerializer(focal, read_only=True, many=True).data
 
     def get_partner_focal_point(self, obj):
-        return PersonSerializer(obj.partner_focal_point.filter(active=True), read_only=True, many=True).data
+        partner_fp = getattr(obj, 'prefetched_partner_focal_point_active', None)
+        if partner_fp is None:
+            partner_fp = obj.partner_focal_point.filter(active=True)
+        return PersonSerializer(partner_fp, read_only=True, many=True).data
 
 
 class ProgrammeDocumentListSerializer(ProgrammeDocumentSerializer):

--- a/django_api/etools_prp/apps/unicef/views.py
+++ b/django_api/etools_prp/apps/unicef/views.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from django.db.models import Prefetch
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 
@@ -70,7 +71,7 @@ from etools_prp.apps.utils.mixins import ListExportMixin, ObjectExportMixin
 from .export_report import ProgressReportXLSXExporter
 from .filters import ProgrammeDocumentFilter, ProgrammeDocumentIndicatorFilter, ProgressReportFilter
 from .import_report import ProgressReportXLSXReader
-from .models import ProgrammeDocument, ProgressReport, ProgressReportAttachment
+from .models import Person, ProgrammeDocument, ProgressReport, ProgressReportAttachment
 from .serializers import (
     ImportUserRealmsSerializer,
     LLOutputSerializer,
@@ -166,7 +167,25 @@ class ProgrammeDocumentDetailsAPIView(RetrieveAPIView):
 
     def get_object(self, pd_id):
         try:
-            return ProgrammeDocument.objects.get(
+            return ProgrammeDocument.objects.prefetch_related(
+                'sections',
+                'reporting_periods',
+                Prefetch(
+                    'unicef_officers',
+                    queryset=Person.objects.filter(active=True),
+                    to_attr='prefetched_unicef_officers_active',
+                ),
+                Prefetch(
+                    'unicef_focal_point',
+                    queryset=Person.objects.filter(active=True),
+                    to_attr='prefetched_unicef_focal_point_active',
+                ),
+                Prefetch(
+                    'partner_focal_point',
+                    queryset=Person.objects.filter(active=True),
+                    to_attr='prefetched_partner_focal_point_active',
+                ),
+            ).get(
                 partner=self.request.user.partner,
                 workspace=self.workspace_id,
                 pk=pd_id)


### PR DESCRIPTION
- added prefetch related to M2M fields
- adjusted serializers



_Why these changes :_ 

`Prefetch` 

ProgrammeDocument has 3 M2M fields : officer_programme_documents, unicef_focal_programme_documents and officer_programme_documents. Using prefetch avoid the N+1 query, making the whole thing faster. 

`select_related(None) `

In PRPLocationsManager.get_queryset, we have : 
**.select_related('parent').defer('geom', 'point')**

Adding  **select_related(None)** to ProgrammeDocument.locations_queryset clears that manager-level default, so the query doesn’t traverse parent, which is otherwise causing tests to fail

`.only('id', 'name', 'admin_level', 'admin_level_name', 'p_code')`

Similarly to how it’s done in **ShortLocationSerializer**, we only keep the columns we need, making the query faster.

`.order_by(‘id’).distinct(‘id’) `

**.disctinct(‘id’)** is faster that **disctint()**, and is kept to avoid duplicates. Removing it makes the following test fail :  **test_detail_api.**

**.order_by(‘id’)** is required for **.distinct(‘id’)** to work 
